### PR TITLE
Use patched version of web3-provider-engine that supports kovan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1454,8 +1454,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000852",
-        "electron-to-chromium": "1.3.48"
+        "caniuse-lite": "1.0.30000902",
+        "electron-to-chromium": "1.3.82"
       }
     },
     "bs-logger": {
@@ -1530,9 +1530,9 @@
       "optional": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000852",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000852.tgz",
-      "integrity": "sha512-NOuitABlrRbIpjtC8HdDnHL9Fi+yH5phDoXlXT7Im++48kll2bUps9dWWdAnBwqT/oEsjobuOLnnJCBjVqadCw=="
+      "version": "1.0.30000902",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000902.tgz",
+      "integrity": "sha512-EZG6qrRHkW715hOFjOrshH2JygbLfhaC8NjjkE5EdGJZhCYbtnJMaRdicB+2AP8xKX3QzW9g3mkDUTHUoBG5rQ=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -1764,7 +1764,7 @@
       "requires": {
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
-        "md5.js": "1.3.4",
+        "md5.js": "1.3.5",
         "ripemd160": "2.0.2",
         "sha.js": "2.4.11"
       }
@@ -1783,9 +1783,9 @@
       }
     },
     "cross-fetch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
-      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
@@ -2028,18 +2028,18 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-      "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+      "version": "1.3.82",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
+      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew=="
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
-        "hash.js": "1.1.4",
+        "hash.js": "1.1.5",
         "hmac-drbg": "1.0.1",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1",
@@ -2165,7 +2165,7 @@
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
         "ethjs-util": "0.1.6",
-        "json-rpc-engine": "3.7.3",
+        "json-rpc-engine": "3.8.0",
         "pify": "2.3.0",
         "tape": "4.9.1"
       }
@@ -2175,9 +2175,9 @@
       "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz",
       "integrity": "sha512-IuK5Iowfs6taluA/3Okmu6EfZcFMq6MQuyrUL1PrCoJstuuBr3TvVeSy3keDyxfbrjFB34nCo538I8G+qMtsbw==",
       "requires": {
-        "cross-fetch": "2.2.2",
+        "cross-fetch": "2.2.3",
         "eth-json-rpc-middleware": "1.6.0",
-        "json-rpc-engine": "3.7.3",
+        "json-rpc-engine": "3.8.0",
         "json-rpc-error": "2.0.0",
         "tape": "4.9.1"
       }
@@ -2195,7 +2195,7 @@
         "ethereumjs-util": "5.2.0",
         "ethereumjs-vm": "2.4.0",
         "fetch-ponyfill": "4.1.0",
-        "json-rpc-engine": "3.7.3",
+        "json-rpc-engine": "3.8.0",
         "json-rpc-error": "2.0.0",
         "json-stable-stringify": "1.0.1",
         "promise-to-callback": "1.0.0",
@@ -2216,8 +2216,17 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "5.2.0"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "requires": {
+            "bn.js": "4.11.8",
+            "ethereumjs-util": "5.2.0"
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -2250,7 +2259,7 @@
             "ethereumjs-tx": "1.3.7",
             "ethereumjs-util": "5.2.0",
             "ethjs-util": "0.1.6",
-            "json-rpc-engine": "3.7.3",
+            "json-rpc-engine": "3.8.0",
             "pify": "2.3.0",
             "tape": "4.9.1"
           },
@@ -2262,6 +2271,11 @@
               }
             }
           }
+        },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
         },
         "ethereumjs-vm": {
           "version": "2.3.4",
@@ -2276,7 +2290,7 @@
             "ethereumjs-util": "5.2.0",
             "fake-merkle-patricia-tree": "1.0.1",
             "functional-red-black-tree": "1.0.1",
-            "merkle-patricia-tree": "2.3.1",
+            "merkle-patricia-tree": "2.3.2",
             "rustbn.js": "0.1.2",
             "safe-buffer": "5.1.2"
           }
@@ -2301,7 +2315,7 @@
             "readable-stream": "2.3.6",
             "request": "2.87.0",
             "semaphore": "1.1.0",
-            "solc": "0.4.24",
+            "solc": "0.4.25",
             "tape": "4.9.1",
             "xhr": "2.5.0",
             "xtend": "4.0.1"
@@ -2310,16 +2324,9 @@
       }
     },
     "ethereum-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
-    },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-      "requires": {
-        "bn.js": "4.11.8",
-        "ethereumjs-util": "5.2.0"
-      }
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -2340,7 +2347,14 @@
         "ethereum-common": "0.2.0",
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
-        "merkle-patricia-tree": "2.3.1"
+        "merkle-patricia-tree": "2.3.2"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        }
       }
     },
     "ethereumjs-common": {
@@ -2355,13 +2369,6 @@
       "requires": {
         "ethereum-common": "0.0.18",
         "ethereumjs-util": "5.2.0"
-      },
-      "dependencies": {
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        }
       }
     },
     "ethereumjs-util": {
@@ -2375,7 +2382,7 @@
         "keccak": "1.4.0",
         "rlp": "2.1.0",
         "safe-buffer": "5.1.2",
-        "secp256k1": "3.5.0"
+        "secp256k1": "3.5.2"
       }
     },
     "ethereumjs-vm": {
@@ -2391,7 +2398,7 @@
         "ethereumjs-util": "5.2.0",
         "fake-merkle-patricia-tree": "1.0.1",
         "functional-red-black-tree": "1.0.1",
-        "merkle-patricia-tree": "2.3.1",
+        "merkle-patricia-tree": "2.3.2",
         "rustbn.js": "0.2.0",
         "safe-buffer": "5.1.2"
       },
@@ -2412,12 +2419,17 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "1.3.4",
+        "md5.js": "1.3.5",
         "safe-buffer": "5.1.2"
       }
     },
@@ -3458,9 +3470,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1"
@@ -3477,7 +3489,7 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.4",
+        "hash.js": "1.1.5",
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
@@ -5067,16 +5079,16 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-rpc-engine": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
-      "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
+      "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
       "requires": {
         "async": "2.6.1",
         "babel-preset-env": "1.7.0",
         "babelify": "7.3.0",
-        "clone": "2.1.2",
         "json-rpc-error": "2.0.0",
-        "promise-to-callback": "1.0.0"
+        "promise-to-callback": "1.0.0",
+        "safe-event-emitter": "1.0.1"
       }
     },
     "json-rpc-error": {
@@ -5464,12 +5476,13 @@
       "dev": true
     },
     "md5.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
-      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
         "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "mem": {
@@ -5525,9 +5538,9 @@
       }
     },
     "merkle-patricia-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
-      "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "requires": {
         "async": "1.5.2",
         "ethereumjs-util": "5.2.0",
@@ -6545,6 +6558,14 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-event-emitter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
+      "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
+      "requires": {
+        "events": "3.0.0"
+      }
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -6865,16 +6886,16 @@
       "dev": true
     },
     "secp256k1": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
+      "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",
         "bn.js": "4.11.8",
         "create-hash": "1.2.0",
         "drbg.js": "1.0.1",
-        "elliptic": "6.4.0",
+        "elliptic": "6.4.1",
         "nan": "2.10.0",
         "safe-buffer": "5.1.2"
       }
@@ -7089,9 +7110,9 @@
       }
     },
     "solc": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.25.tgz",
+      "integrity": "sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -8150,14 +8171,12 @@
       }
     },
     "web3-provider-engine": {
-      "version": "14.0.6",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.6.tgz",
-      "integrity": "sha512-tr5cGSyxfSC/JqiUpBlJtfZpwQf1yAA8L/zy1C6fDFm0ntR974pobJ4v4676atpZne4Ze5VFy3kPPahHe9gQiQ==",
+      "version": "github:BitskiCo/provider-engine#a3172d6e1cbf01fc0e67e7ed30f4b4763b5ab1ca",
       "requires": {
         "async": "2.6.1",
         "backoff": "2.5.0",
         "clone": "2.1.2",
-        "cross-fetch": "2.2.2",
+        "cross-fetch": "2.2.3",
         "eth-block-tracker": "3.0.1",
         "eth-json-rpc-infura": "3.1.2",
         "eth-sig-util": "1.4.2",
@@ -8171,20 +8190,9 @@
         "readable-stream": "2.3.6",
         "request": "2.87.0",
         "semaphore": "1.1.0",
-        "tape": "4.9.1",
         "ws": "5.2.2",
         "xhr": "2.5.0",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "1.0.0"
-          }
-        }
       }
     },
     "webidl-conversions": {
@@ -8309,7 +8317,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
       "requires": {
         "async-limiter": "1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/events": "^1.2.0",
     "json-rpc-error": "^2.0.0",
     "oidc-client": ">=1.5.2",
-    "web3-provider-engine": "^14.0.6"
+    "web3-provider-engine": "github:BitskiCo/provider-engine#fix/kovan-subscriptions"
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",


### PR DESCRIPTION
This fixes an issue with using Kovan and web3-provider-engine. Basically, Kovan’s block difficulty is too high to be represented as a number in javascript. This causes block subscriptions to fail. The patched branch uses a better method to convert the difficulty value back to a hex string.