### PR TITLE
Cache accounts from openid profile, enable unauthenticated requests

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,6 +15,7 @@
 * ["bitski"](#_bitski_)
 * ["components/connect-button"](#_components_connect_button_)
 * ["components/dialog"](#_components_dialog_)
+* ["subproviders/authenticated-cache"](#_subproviders_authenticated_cache_)
 * ["subproviders/authenticated-fetch"](#_subproviders_authenticated_fetch_)
 * ["subproviders/authorization-handler"](#_subproviders_authorization_handler_)
 * ["subproviders/iframe"](#_subproviders_iframe_)
@@ -754,7 +755,7 @@ new Bitski(clientId: string, redirectUri?: undefined | string, postLogoutRedirec
 ```javascript
 private var authProvider: AuthProvider
 ```
-<small>*Defined in [bitski.ts:28](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L28)*</small>
+<small>*Defined in [bitski.ts:29](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L29)*</small>
 
 
 <a id="_bitski_.bitski.clientid"></a>
@@ -763,7 +764,7 @@ private var authProvider: AuthProvider
 ```javascript
 private var clientId: string
 ```
-<small>*Defined in [bitski.ts:27](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L27)*</small>
+<small>*Defined in [bitski.ts:28](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L28)*</small>
 
 
 <a id="_bitski_.bitski.engines"></a>
@@ -772,7 +773,7 @@ private var clientId: string
 ```javascript
 private var engines: Map<string, any> =  new Map<string, ProviderEngine>()
 ```
-<small>*Defined in [bitski.ts:26](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L26)*</small>
+<small>*Defined in [bitski.ts:27](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L27)*</small>
 
 
 
@@ -891,7 +892,7 @@ private function createBitskiEngine(networkName?: undefined | string, options?: 
 
 
 ```typescript
-private function createEngine(fetchSubprovider: Subprovider, authorizationSubprovider: AuthorizationHandler, options?: any): ProviderEngine
+private function createEngine(subproviders: Subprovider[], options?: any): ProviderEngine
 ```
 <small>*Defined in [bitski.ts:147](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L147)*</small>
 
@@ -901,8 +902,7 @@ private function createEngine(fetchSubprovider: Subprovider, authorizationSubpro
 
 | Param | Type | Description |
 | ------ | ------ | ------ |
-| fetchSubprovider | `Subprovider`   |  - |
-| authorizationSubprovider | [AuthorizationHandler](#_subproviders_authorization_handler_.authorizationhandler)   |  - |
+| subproviders | `Subprovider[]`   |  - |
 | options _(Optional)_ | `any`   |  - |
 
 
@@ -929,7 +929,7 @@ private function createEngine(fetchSubprovider: Subprovider, authorizationSubpro
 ```typescript
 private function createThirdPartyEngine(rpcUrl: string, options?: any): ProviderEngine
 ```
-<small>*Defined in [bitski.ts:204](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L204)*</small>
+<small>*Defined in [bitski.ts:205](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L205)*</small>
 
 
 
@@ -1258,7 +1258,7 @@ function signOut(): Promise<void>
 ```javascript
 var ENABLE_CACHE: true = true
 ```
-<small>*Defined in [bitski.ts:20](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L20)*</small>
+<small>*Defined in [bitski.ts:21](https://github.com/BitskiCo/bitski-js/blob/master/src/bitski.ts#L21)*</small>
 
 
 
@@ -2113,6 +2113,220 @@ var DEFAULT_DIALOG_WIDTH: 490 = 490
 
 ---
 
+<a id="_subproviders_authenticated_cache_"></a>
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider"></a>
+
+##  AuthenticatedCacheSubprovider
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.constructor"></a>
+### constructor
+```typescript
+new AuthenticatedCacheSubprovider(authProvider: any): AuthenticatedCacheSubprovider
+```
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| authProvider | `any`   |  - |
+
+
+
+##### Return Value
+[AuthenticatedCacheSubprovider](#_subproviders_authenticated_cache_.authenticatedcachesubprovider)
+
+
+
+
+
+---
+
+### Properties
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.authprovider"></a>
+
+#### authProvider
+```javascript
+private var authProvider: AuthProvider
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:10](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L10)*</small>
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.cachedvalues"></a>
+
+#### cachedValues
+```javascript
+private var cachedValues: Map<string, any>
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:11](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L11)*</small>
+
+
+
+
+---
+
+### Methods
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.checkcachedvalues"></a>
+
+#### checkCachedValues
+
+
+
+
+##### Declaration
+
+
+```typescript
+private function checkCachedValues(methodName: string): Promise<any>
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:49](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L49)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| methodName | `string`   |  - |
+
+
+
+##### Return Value
+`Promise<any>`
+
+
+
+
+
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.getaccounts"></a>
+
+#### getAccounts
+
+
+
+
+##### Declaration
+
+
+```typescript
+private function getAccounts(): Promise<[string]>
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:63](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L63)*</small>
+
+
+
+##### Return Value
+`Promise<[string]>`
+
+
+
+
+
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.handlerequest"></a>
+
+#### handleRequest
+
+
+
+
+##### Declaration
+
+
+```typescript
+function handleRequest(payload: any, next: any, end: any): any
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:19](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L19)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| payload | `any`   |  - |
+| next | `any`   |  - |
+| end | `any`   |  - |
+
+
+
+##### Return Value
+`any`
+
+
+
+
+
+
+
+<a id="_subproviders_authenticated_cache_.authenticatedcachesubprovider.supportscache"></a>
+
+#### supportsCache
+
+
+
+
+##### Declaration
+
+
+```typescript
+private function supportsCache(methodName: string): boolean
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:45](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L45)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| methodName | `string`   |  - |
+
+
+
+##### Return Value
+`boolean`
+
+
+
+
+
+
+
+
+
+---
+
+
+### Relationships
+##### Extends
+* [&quot;subproviders/authenticated-cache&quot;](#_subproviders_authenticated_cache_).[AuthenticatedCacheSubprovider](#_subproviders_authenticated_cache_.authenticatedcachesubprovider)
+
+---
+
+
+<a id="_subproviders_authenticated_cache_.cached_methods"></a>
+
+#### «Const» CACHED_METHODS
+
+
+```javascript
+var CACHED_METHODS: string[] =  ['eth_accounts']
+```
+<small>*Defined in [subproviders/authenticated-cache.ts:4](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-cache.ts#L4)*</small>
+
+
+
+
+
+
+
+---
+
 <a id="_subproviders_authenticated_fetch_"></a>
 
 
@@ -2153,7 +2367,7 @@ new AuthenticatedFetchSubprovider(rpcUrl: string, debug: boolean, authProvider: 
 ```javascript
 private var authProvider: AuthProvider
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:28](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L28)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:31](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L31)*</small>
 
 
 <a id="_subproviders_authenticated_fetch_.authenticatedfetchsubprovider.defaultheaders"></a>
@@ -2162,7 +2376,7 @@ private var authProvider: AuthProvider
 ```javascript
 private var defaultHeaders: object
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:29](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L29)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:32](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L32)*</small>
 
 
 
@@ -2218,7 +2432,7 @@ private function generateParameters(payload: any, accessToken?: undefined | stri
 ```typescript
 function handleAuthenticatedRequest(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:45](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L45)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:48](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L48)*</small>
 
 
 
@@ -2250,7 +2464,7 @@ function handleAuthenticatedRequest(payload: any, next: any, end: any)
 ```typescript
 function handleRequest(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:37](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L37)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:40](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L40)*</small>
 
 
 
@@ -2282,7 +2496,7 @@ function handleRequest(payload: any, next: any, end: any)
 ```typescript
 function handleUnauthenticatedRequest(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:54](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L54)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:57](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L57)*</small>
 
 
 
@@ -2314,7 +2528,7 @@ function handleUnauthenticatedRequest(payload: any, next: any, end: any)
 ```typescript
 private function requiresAuthentication(payload: any): boolean
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:59](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L59)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:62](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L62)*</small>
 
 
 
@@ -2348,7 +2562,7 @@ private function requiresAuthentication(payload: any): boolean
 ```typescript
 private function sendRequest(parameters: object, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authenticated-fetch.ts:99](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L99)*</small>
+<small>*Defined in [subproviders/authenticated-fetch.ts:97](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authenticated-fetch.ts#L97)*</small>
 
 
 
@@ -2495,7 +2709,7 @@ new AuthorizationHandler(opts?: any): AuthorizationHandler
 ```javascript
 private var authorizedMethods: [string]
 ```
-<small>*Defined in [subproviders/authorization-handler.ts:8](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L8)*</small>
+<small>*Defined in [subproviders/authorization-handler.ts:11](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L11)*</small>
 
 
 
@@ -2516,7 +2730,7 @@ private var authorizedMethods: [string]
 ```typescript
 function handleAuthorization(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authorization-handler.ts:23](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L23)*</small>
+<small>*Defined in [subproviders/authorization-handler.ts:26](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L26)*</small>
 
 
 
@@ -2548,7 +2762,7 @@ function handleAuthorization(payload: any, next: any, end: any)
 ```typescript
 function handleRequest(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/authorization-handler.ts:15](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L15)*</small>
+<small>*Defined in [subproviders/authorization-handler.ts:18](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L18)*</small>
 
 
 
@@ -2580,7 +2794,7 @@ function handleRequest(payload: any, next: any, end: any)
 ```typescript
 private function requiresAuthorization(method: string): boolean
 ```
-<small>*Defined in [subproviders/authorization-handler.ts:28](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L28)*</small>
+<small>*Defined in [subproviders/authorization-handler.ts:31](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/authorization-handler.ts#L31)*</small>
 
 
 
@@ -2670,7 +2884,7 @@ new IFrameSubprovider(webBaseUrl: string, networkName: string, authProvider: Aut
 ```javascript
 private var authProvider: AuthProvider
 ```
-<small>*Defined in [subproviders/iframe.ts:12](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L12)*</small>
+<small>*Defined in [subproviders/iframe.ts:15](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L15)*</small>
 
 
 <a id="_subproviders_iframe_.iframesubprovider.currentrequest"></a>
@@ -2679,7 +2893,7 @@ private var authProvider: AuthProvider
 ```javascript
 private var currentRequest: Request
 ```
-<small>*Defined in [subproviders/iframe.ts:13](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L13)*</small>
+<small>*Defined in [subproviders/iframe.ts:16](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L16)*</small>
 
 
 <a id="_subproviders_iframe_.iframesubprovider.currentrequestdialog"></a>
@@ -2688,7 +2902,7 @@ private var currentRequest: Request
 ```javascript
 var currentRequestDialog: Dialog
 ```
-<small>*Defined in [subproviders/iframe.ts:9](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L9)*</small>
+<small>*Defined in [subproviders/iframe.ts:12](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L12)*</small>
 
 
 <a id="_subproviders_iframe_.iframesubprovider.networkname"></a>
@@ -2697,7 +2911,7 @@ var currentRequestDialog: Dialog
 ```javascript
 private var networkName: string
 ```
-<small>*Defined in [subproviders/iframe.ts:11](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L11)*</small>
+<small>*Defined in [subproviders/iframe.ts:14](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L14)*</small>
 
 
 <a id="_subproviders_iframe_.iframesubprovider.webbaseurl"></a>
@@ -2706,7 +2920,7 @@ private var networkName: string
 ```javascript
 private var webBaseUrl: string
 ```
-<small>*Defined in [subproviders/iframe.ts:10](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L10)*</small>
+<small>*Defined in [subproviders/iframe.ts:13](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L13)*</small>
 
 
 
@@ -2727,7 +2941,7 @@ private var webBaseUrl: string
 ```typescript
 function handleAuthorization(payload: any, _: any, end: any)
 ```
-<small>*Defined in [subproviders/iframe.ts:23](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L23)*</small>
+<small>*Defined in [subproviders/iframe.ts:26](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L26)*</small>
 
 
 
@@ -2760,7 +2974,7 @@ function handleAuthorization(payload: any, _: any, end: any)
 ```typescript
 function receiveMessage(event: MessageEvent)
 ```
-<small>*Defined in [subproviders/iframe.ts:31](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L31)*</small>
+<small>*Defined in [subproviders/iframe.ts:34](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L34)*</small>
 
 
 
@@ -2790,7 +3004,7 @@ function receiveMessage(event: MessageEvent)
 ```typescript
 private function showAuthorizationModal(element: any, payload: any, end: any)
 ```
-<small>*Defined in [subproviders/iframe.ts:95](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L95)*</small>
+<small>*Defined in [subproviders/iframe.ts:98](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L98)*</small>
 
 
 
@@ -2822,7 +3036,7 @@ private function showAuthorizationModal(element: any, payload: any, end: any)
 ```typescript
 private function showBitskiModal(accessToken: any, payload: any, end: any)
 ```
-<small>*Defined in [subproviders/iframe.ts:72](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L72)*</small>
+<small>*Defined in [subproviders/iframe.ts:75](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L75)*</small>
 
 
 
@@ -2854,7 +3068,7 @@ private function showBitskiModal(accessToken: any, payload: any, end: any)
 ```typescript
 private function urlForMethod(method: string): string | undefined
 ```
-<small>*Defined in [subproviders/iframe.ts:61](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L61)*</small>
+<small>*Defined in [subproviders/iframe.ts:64](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/iframe.ts#L64)*</small>
 
 
 
@@ -2942,7 +3156,7 @@ new LocalDialogSubprovider(opts?: any): LocalDialogSubprovider
 ```javascript
 private var currentDialog: Dialog
 ```
-<small>*Defined in [subproviders/local-dialog.ts:9](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L9)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:12](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L12)*</small>
 
 
 <a id="_subproviders_local_dialog_.localdialogsubprovider.currentrequest"></a>
@@ -2951,7 +3165,7 @@ private var currentDialog: Dialog
 ```javascript
 private var currentRequest: Request
 ```
-<small>*Defined in [subproviders/local-dialog.ts:10](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L10)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:13](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L13)*</small>
 
 
 <a id="_subproviders_local_dialog_.localdialogsubprovider.transactionwindow"></a>
@@ -2960,7 +3174,7 @@ private var currentRequest: Request
 ```javascript
 private var transactionWindow: any
 ```
-<small>*Defined in [subproviders/local-dialog.ts:11](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L11)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:14](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L14)*</small>
 
 
 
@@ -2981,7 +3195,7 @@ private var transactionWindow: any
 ```typescript
 private function createDefinition(label: any, value: any): HTMLDListElement
 ```
-<small>*Defined in [subproviders/local-dialog.ts:44](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L44)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:47](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L47)*</small>
 
 
 
@@ -3016,7 +3230,7 @@ private function createDefinition(label: any, value: any): HTMLDListElement
 ```typescript
 private function createTransactionWindow(payload: any, submitHandler: any, cancelHandler: any): any
 ```
-<small>*Defined in [subproviders/local-dialog.ts:67](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L67)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:70](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L70)*</small>
 
 
 
@@ -3052,7 +3266,7 @@ private function createTransactionWindow(payload: any, submitHandler: any, cance
 ```typescript
 private function displayModal(element: any, payload: any, end: any)
 ```
-<small>*Defined in [subproviders/local-dialog.ts:148](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L148)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:151](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L151)*</small>
 
 
 
@@ -3084,7 +3298,7 @@ private function displayModal(element: any, payload: any, end: any)
 ```typescript
 function handleAuthorization(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/local-dialog.ts:17](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L17)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:20](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L20)*</small>
 
 
 
@@ -3117,7 +3331,7 @@ function handleAuthorization(payload: any, next: any, end: any)
 ```typescript
 private function showTransactionModal(payload: any, next: any, end: any)
 ```
-<small>*Defined in [subproviders/local-dialog.ts:21](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L21)*</small>
+<small>*Defined in [subproviders/local-dialog.ts:24](https://github.com/BitskiCo/bitski-js/blob/master/src/subproviders/local-dialog.ts#L24)*</small>
 
 
 

--- a/src/subproviders/authenticated-cache.ts
+++ b/src/subproviders/authenticated-cache.ts
@@ -1,0 +1,72 @@
+import Subprovider from 'web3-provider-engine/subproviders/subprovider';
+import { AuthProvider } from '../auth/auth-provider';
+
+const CACHED_METHODS = ['eth_accounts'];
+
+/*
+ * Subprovider that caches values related to the user.
+ */
+export class AuthenticatedCacheSubprovider extends Subprovider {
+    private authProvider: AuthProvider;
+    private cachedValues: Map<string, any>;
+
+    constructor(authProvider) {
+        super();
+        this.authProvider = authProvider;
+        this.cachedValues = new Map<string, any>();
+    }
+
+    public handleRequest(payload, next, end) {
+        // Only evaluate matching methods
+        if (this.supportsCache(payload.method) === false) {
+            return next();
+        }
+
+        // Allow overriding the cache
+        if (payload.skipCache) {
+            return next();
+        }
+
+        // Load from cache
+        this.checkCachedValues(payload.method).then(value => {
+            if (value !== undefined) {
+                // Value for method is cached, return value
+                end(undefined, value);
+            } else {
+                // Value for method is not cached, fallback to fetch
+                next();
+            }
+        }).catch(_ => {
+            // If method is not supported, or we encounter an error, fallback to fetch provider
+            return next();
+        });
+    }
+
+    private supportsCache(methodName: string): boolean {
+        return CACHED_METHODS.includes(methodName);
+    }
+
+    private checkCachedValues(methodName: string): Promise<any> {
+        // First, check in-memory cache
+        if (this.cachedValues.has(methodName)) {
+            return Promise.resolve(this.cachedValues.get(methodName));
+        }
+        // Fallback to local-storage cache
+        switch (methodName) {
+        case 'eth_accounts':
+            return this.getAccounts();
+        default:
+            return Promise.reject(new Error('Method not supported'));
+        }
+    }
+
+    private getAccounts(): Promise<[string]> {
+        //TODO: Move this to a subscription model and load into memory automatically
+        return this.authProvider.getUser().then(user => {
+            if (user && user.profile && user.profile.accounts) {
+                this.cachedValues.set('eth_accounts', user.profile.accounts);
+                return user.profile.accounts;
+            }
+        });
+    }
+}

--- a/src/subproviders/authenticated-fetch.ts
+++ b/src/subproviders/authenticated-fetch.ts
@@ -24,6 +24,9 @@ function isErrorRetriable(err) {
     return RETRIABLE_ERRORS.some((phrase) => errMsg.includes(phrase));
 }
 
+/*
+ * Subprovider that fetches over HTTP and manages authentication headers
+ */
 export class AuthenticatedFetchSubprovider extends FetchSubprovider {
     private authProvider: AuthProvider;
     private defaultHeaders: object;
@@ -57,26 +60,21 @@ export class AuthenticatedFetchSubprovider extends FetchSubprovider {
     }
 
     private requiresAuthentication(payload) {
-        return true;
-
-        // TODO: Allow unauthenticated requests (requires backend change)
-        // return AUTHENTICATED_METHODS.some((method) => (payload['method'] === method));
+        return AUTHENTICATED_METHODS.includes(payload.method);
     }
 
     private generateParameters(payload, accessToken?: string): object {
-        const self = this;
-
         // overwrite id to not conflict with other concurrent users
         const newPayload = createPayload(payload);
         // remove extra parameter from request
         delete newPayload.origin;
 
-        const headers: object = {
+        let headers: object = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         };
 
-        Object.assign(headers, this.defaultHeaders);
+        headers = Object.assign({}, headers, this.defaultHeaders);
 
         const originDomain = payload['origin'];
         if (super.originHttpHeaderKey && originDomain) {

--- a/src/subproviders/authorization-handler.ts
+++ b/src/subproviders/authorization-handler.ts
@@ -3,6 +3,9 @@ import Subprovider from 'web3-provider-engine/subproviders/subprovider';
 
 const DEFAULT_AUTHORIZED_METHODS = ['eth_sendTransaction', 'eth_sign', 'eth_signTypedData', 'personal_sign'];
 
+/*
+ * Base Subprovider that requests authorization for specific methods. Meant to be extended.
+ */
 export class AuthorizationHandler extends Subprovider {
 
   private authorizedMethods: [string];
@@ -22,7 +25,7 @@ export class AuthorizationHandler extends Subprovider {
 
   public handleAuthorization(payload, next, end): void {
     //Default implementation
-    end(new JsonRpcError.InternalError(), undefined);
+    end(new JsonRpcError.InternalError());
   }
 
   private requiresAuthorization(method: string): boolean {

--- a/src/subproviders/iframe.ts
+++ b/src/subproviders/iframe.ts
@@ -5,6 +5,9 @@ import { AuthorizationHandler } from './authorization-handler';
 
 type Request = [any, any];
 
+/*
+ * An AuthorizationHandler Subprovider that uses an iframe to get authorization from the user.
+ */
 export class IFrameSubprovider extends AuthorizationHandler {
     public currentRequestDialog?: Dialog;
     private webBaseUrl: string;

--- a/src/subproviders/local-dialog.ts
+++ b/src/subproviders/local-dialog.ts
@@ -4,6 +4,9 @@ import { AuthorizationHandler } from './authorization-handler';
 
 type Request = [any, any];
 
+/*
+ * An AuthorizationHandler Subprovider that uses a local dialog to request permission from the user. Meant for development mode only.
+ */
 export class LocalDialogSubprovider extends AuthorizationHandler {
 
   private currentDialog?: Dialog;

--- a/tests/authenticated-cache.test.ts
+++ b/tests/authenticated-cache.test.ts
@@ -1,0 +1,227 @@
+import { AuthenticatedCacheSubprovider } from '../src/subproviders/authenticated-cache';
+import { InMemoryWebStorage, WebStorageStateStore } from 'oidc-client';
+import { OpenidAuthProvider } from '../src/auth/openid-auth-provider';
+
+const mockUser = {
+  access_token: 'test-access-token',
+  expired: false,
+  expires_at: Math.floor(Date.now() / 1000) + 60,
+  expires_in: 60,
+  id_token: 'test-id-token',
+  profile: {
+    accounts: ['test-account']
+  },
+  scope: 'openid',
+  scopes: [],
+  session_state: null,
+  state: null,
+  toStorageString: jest.fn().mockReturnValue('{ "id_token": "test-id-token", "session_state": "test-session-state", "access_token": "test-access-token" }'),
+  token_type: '',
+};
+
+const clientID = 'test-client-id';
+
+function createAuthProvider(): OpenidAuthProvider {
+  const store = new InMemoryWebStorage();
+  const stateStore = new WebStorageStateStore({ prefix: 'bitski.', store });
+  const otherSettings = {
+    stateStore,
+    userStore: stateStore,
+  };
+  return new OpenidAuthProvider(clientID, undefined, undefined, otherSettings);
+}
+
+describe('authorization handler', () => {
+
+  test('it ignores methods outside of scope', (done) => {
+    const authProvider = createAuthProvider();
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'foo',
+      params: []
+    };
+
+    const next = () => {
+      done();
+    }
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it forwards calls when no cached data is available', (done) => {
+    const authProvider = createAuthProvider();
+
+    // getUser will return undefined
+    const getUserSpy = jest.spyOn(authProvider, 'getUser');
+    getUserSpy.mockResolvedValue(undefined);
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      params: []
+    };
+
+    const next = () => {
+      done();
+    }
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it handles calls when cached data is available in memory', (done) => {
+    expect.assertions(2);
+
+    const authProvider = createAuthProvider();
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    provider.cachedValues.set('eth_accounts', ['1234']);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      params: []
+    };
+
+    const next = () => {
+      done.fail('next() should not have been called');
+    }
+
+    const end = (error, value) => {
+      expect(error).toBeUndefined();
+      expect(value).toEqual(['1234']);
+      done();
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it handles calls when cached data is available in auth provider', (done) => {
+    expect.assertions(2);
+    const authProvider = createAuthProvider();
+
+    // getUser will return mock user with accounts
+    const getUserSpy = jest.spyOn(authProvider, 'getUser').mockResolvedValue(mockUser);
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      params: []
+    };
+
+    const next = () => {
+      done.fail('next() should not have been called');
+    }
+
+    const end = (error, value) => {
+      expect(error).toBeUndefined();
+      expect(value).toEqual(['test-account']);
+      done();
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it forwards calls when cached data is not available in auth provider', (done) => {
+    const authProvider = createAuthProvider();
+
+    // getUser will return user with no accounts value
+    let user = mockUser;
+    delete user.profile.accounts;
+    const getUserSpy = jest.spyOn(authProvider, 'getUser').mockResolvedValue(user);
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      params: []
+    };
+
+    const next = () => {
+      done();
+    }
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it forwards calls when skipCache is set in the payload', (done) => {
+    expect.assertions(1);
+    const authProvider = createAuthProvider();
+
+    // getUser will return user with no accounts value
+    const getUserSpy = jest.spyOn(authProvider, 'getUser').mockResolvedValue(mockUser);
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      skipCache: true,
+      params: []
+    };
+
+    const next = () => {
+      expect(getUserSpy).not.toHaveBeenCalled();
+      done();
+    }
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+  test('it forwards calls when encountering errors loading user', (done) => {
+    expect.assertions(1);
+    const authProvider = createAuthProvider();
+
+    // getUser will return user with no accounts value
+    const getUserSpy = jest.spyOn(authProvider, 'getUser').mockRejectedValue(new Error('Unauthorized'));
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_accounts',
+      params: []
+    };
+
+    const next = () => {
+      expect(getUserSpy).toHaveBeenCalled();
+      done();
+    }
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    }
+
+    provider.handleRequest(payload, next, end);
+  });
+
+});


### PR DESCRIPTION
- Adds `AuthenticatedCacheSubprovider` to handle cached user data (eventually we may have other things besides accounts?)
- Adds logic to determine which requests need an access token
- Fix bug with headers not being passed through
- Adds tests for new features