### PR TITLE
Fix issue with bundling

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski",
-  "version": "0.2.0-beta.13",
+  "version": "0.2.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/provider/package-lock.json
+++ b/packages/provider/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski-provider",
-  "version": "0.2.0-beta.13",
+  "version": "0.2.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/provider/tsconfig.json
+++ b/packages/provider/tsconfig.json
@@ -3,7 +3,6 @@
     "outDir": "dist",
     "noImplicitAny": false,
     "strict": true,
-    "target": "es2017",
     "moduleResolution": "node",
     "lib": ["es2017", "dom"],
     "esModuleInterop": true,

--- a/packages/provider/tsconfig.main.json
+++ b/packages/provider/tsconfig.main.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "ES5",
     "outDir": "lib",
-    "module": "commonjs",
+    "module": "umd",
     "declaration": true,
     "sourceMap": true
   }

--- a/packages/provider/tsconfig.module.json
+++ b/packages/provider/tsconfig.module.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "ES2017",
     "outDir": "dist/",
     "module": "es6"
   }


### PR DESCRIPTION
Browserify was not bundling and transforming bitski-provider properly. The fix was to make bitski-provider export the main file as ES5 instead of ES2017.