### PR TITLE
Save signed in state with redirect flow

### DIFF
--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -142,7 +142,11 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
     public signInCallback(method: OAuthSignInMethod, url?: string): Promise<User> {
         switch (method) {
         case OAuthSignInMethod.Redirect:
-            return this.userManager.signinRedirectCallback(url || window.location.href);
+            return this.userManager.signinRedirectCallback(url || window.location.href).then((user) => {
+                // the redirect flow does not complete the sign in promise
+                this.hasSignedIn = true;
+                return user;
+            });
         case OAuthSignInMethod.Popup:
             return this.userManager.signinPopupCallback(url || window.location.href);
         case OAuthSignInMethod.Silent:

--- a/packages/browser/tests/auth-provider.test.ts
+++ b/packages/browser/tests/auth-provider.test.ts
@@ -139,6 +139,16 @@ describe('signing in', () => {
     });
   });
 
+  test('should set hasSignedIn when calling the redirect callback', () => {
+    const authProvider = createInstance();
+    const signingRedirectMock = jest.spyOn(authProvider.userManager, 'signinRedirectCallback').mockResolvedValue(dummyUser);
+    return authProvider.signInCallback(OAuthSignInMethod.Redirect, 'blah').then((user) => {
+      expect(authProvider.hasSignedIn).toBe(true);
+      expect(user).toMatchObject(dummyUser);
+      expect(signingRedirectMock).toHaveBeenCalled();
+    });
+  });
+
   test('should handle silent sign in', () => {
     const authProvider = createInstance();
     const signinSilentMock = jest.spyOn(authProvider.userManager, 'signinSilent').mockResolvedValue(dummyUser);


### PR DESCRIPTION
Fixes an issue where the cached signed in state was not being set for the redirect flow due to the sign in promise never resolving since it redirects.