### PR TITLE
Fix issue with using our provider with Truffle

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2388,6 +2388,35 @@ new BitskiEngine(options: any): BitskiEngine
 
 
 
+<a id="undefined"></a>
+
+#### send
+
+
+
+
+##### Declaration
+
+
+```typescript
+function send(payload: JSONRPCRequestPayload)
+```
+<small>*Defined in [provider/src/bitski-engine.ts:31](https://github.com/BitskiCo/bitski-js/blob/master/packages/provider/src/bitski-engine.ts#L31)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| payload | `JSONRPCRequestPayload`   |   |
+
+
+
+
+
+
+
 
 
 

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -1,5 +1,6 @@
 /// <reference path="../types/web3-provider-engine.d.ts" />
 
+import { JSONRPCRequestPayload } from 'ethereum-protocol';
 import Web3ProviderEngine from 'web3-provider-engine';
 import CacheSubprovider from 'web3-provider-engine/subproviders/cache';
 import DefaultFixtures from 'web3-provider-engine/subproviders/default-fixture';
@@ -24,6 +25,16 @@ export class BitskiEngine extends Web3ProviderEngine {
 
     this.addProvider(filterAndSubsSubprovider);
     this.addProvider(new InflightCacheSubprovider());
+  }
+
+  // Some versions of web3 prefer to use send(payload, callback) instead of sendAsync() with a callback.
+  public send(payload: JSONRPCRequestPayload) {
+    // Typescript doesn't like overrides with overloads, so use arguments array.
+    if (typeof arguments[1] === 'function') {
+      this.sendAsync(payload, arguments[1]);
+    } else {
+      throw new Error('synchronous requests are not supported');
+    }
   }
 
 }

--- a/packages/provider/tests/bitski-engine.test.ts
+++ b/packages/provider/tests/bitski-engine.test.ts
@@ -3,3 +3,12 @@ import { BitskiEngine } from "../src";
 test('it exists', () => {
   const engine = new BitskiEngine({});
 });
+
+test('it forwards sends when callback is present', () => {
+  const engine = new BitskiEngine({});
+  engine.start();
+  const spy = jest.spyOn(engine, 'sendAsync');
+  // @ts-ignore
+  engine.send({}, jest.fn());
+  expect(spy).toBeCalled();
+});


### PR DESCRIPTION
We have to support “send” not just “sendAsync”. I believe this is legacy from web3 pre-1.0, but should allow us to support more folks.