### PR TITLE
Add nonce tracking and automatic nonce / gas / gasPrice population to bitski-provider

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -211,7 +211,14 @@ new AuthenticatedCacheSubprovider(authProvider: any): AuthenticatedCacheSubprovi
 
 ---
 
+### Properties
+
+
+
+---
+
 ### Methods
+
 <a id="undefined"></a>
 
 #### handleRequest
@@ -250,12 +257,13 @@ function handleRequest(payload: any, next: any, end: any): any
 
 
 
+
 ---
 
 
 ### Relationships
 ##### Extends
-* any
+* Subprovider
 
 ---
 
@@ -286,7 +294,14 @@ new AuthorizationHandler(opts?: any): AuthorizationHandler
 
 ---
 
+### Properties
+
+
+
+---
+
 ### Methods
+
 <a id="undefined"></a>
 
 #### handleAuthorization
@@ -353,12 +368,13 @@ function handleRequest(payload: any, next: any, end: any)
 
 
 
+
 ---
 
 
 ### Relationships
 ##### Extends
-* any
+* Subprovider
 
 ---
 
@@ -1271,9 +1287,11 @@ var currentRequestDialog: Dialog
 
 
 
+
 ---
 
 ### Methods
+
 <a id="undefined"></a>
 
 #### handleAuthorization
@@ -1339,6 +1357,7 @@ function receiveMessage(event: MessageEvent)
 
 
 
+
 ---
 
 
@@ -1375,7 +1394,14 @@ new LocalDialogSubprovider(opts?: any): LocalDialogSubprovider
 
 ---
 
+### Properties
+
+
+
+---
+
 ### Methods
+
 <a id="undefined"></a>
 
 #### handleAuthorization
@@ -1400,6 +1426,7 @@ function handleAuthorization(payload: any, next: any, end: any)
 | payload | `any`   |   |
 | next | `any`   |   |
 | end | `any`   |   |
+
 
 
 
@@ -2401,7 +2428,7 @@ new BitskiEngine(options: any): BitskiEngine
 ```typescript
 function send(payload: JSONRPCRequestPayload)
 ```
-<small>*Defined in [provider/src/bitski-engine.ts:31](https://github.com/BitskiCo/bitski-js/blob/master/packages/provider/src/bitski-engine.ts#L31)*</small>
+<small>*Defined in [provider/src/bitski-engine.ts:34](https://github.com/BitskiCo/bitski-js/blob/master/packages/provider/src/bitski-engine.ts#L34)*</small>
 
 
 
@@ -2433,6 +2460,142 @@ function send(payload: JSONRPCRequestPayload)
 * Web3ProviderEngine
 ##### Implements
 * Provider
+
+---
+
+<a id="undefined"></a>
+
+##  NonceTrackerSubprovider
+
+
+
+
+
+
+<a id="undefined"></a>
+### constructor
+```typescript
+new NonceTrackerSubprovider(): NonceTrackerSubprovider
+```
+##### Return Value
+[NonceTrackerSubprovider](#)
+
+
+
+
+
+---
+
+### Properties
+
+
+
+---
+
+### Methods
+
+<a id="undefined"></a>
+
+#### handleRequest
+
+
+
+
+##### Declaration
+
+
+```typescript
+function handleRequest(payload: any, next: any, end: any)
+```
+<small>*Defined in [provider/src/subproviders/nonce-tracker.ts:17](https://github.com/BitskiCo/bitski-js/blob/master/packages/provider/src/subproviders/nonce-tracker.ts#L17)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| payload | `any`   |   |
+| next | `any`   |   |
+| end | `any`   |   |
+
+
+
+
+
+
+
+
+
+
+
+---
+
+
+### Relationships
+##### Extends
+* Subprovider
+
+---
+
+<a id="undefined"></a>
+
+##  TransactionValidatorSubprovider
+
+
+
+
+
+
+### Properties
+
+
+
+---
+
+### Methods
+
+<a id="undefined"></a>
+
+#### handleRequest
+
+
+
+
+##### Declaration
+
+
+```typescript
+function handleRequest(payload: any, next: any, end: any)
+```
+<small>*Defined in [provider/src/subproviders/transaction-validator.ts:10](https://github.com/BitskiCo/bitski-js/blob/master/packages/provider/src/subproviders/transaction-validator.ts#L10)*</small>
+
+
+
+##### Parameters
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| payload | `any`   |   |
+| next | `any`   |   |
+| end | `any`   |   |
+
+
+
+
+
+
+
+
+
+
+
+---
+
+
+### Relationships
+##### Extends
+* Subprovider
 
 ---
 

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -5,9 +5,11 @@ import Web3ProviderEngine from 'web3-provider-engine';
 import CacheSubprovider from 'web3-provider-engine/subproviders/cache';
 import DefaultFixtures from 'web3-provider-engine/subproviders/default-fixture';
 import InflightCacheSubprovider from 'web3-provider-engine/subproviders/inflight-cache';
-import NonceTrackerSubprovider from 'web3-provider-engine/subproviders/nonce-tracker';
 import SanitizingSubprovider from 'web3-provider-engine/subproviders/sanitizer';
 import SubscriptionSubprovider from 'web3-provider-engine/subproviders/subscriptions';
+
+import { NonceTrackerSubprovider } from './subproviders/nonce-tracker';
+import { TransactionValidatorSubprovider } from './subproviders/transaction-validator';
 
 export class BitskiEngine extends Web3ProviderEngine {
 
@@ -15,6 +17,7 @@ export class BitskiEngine extends Web3ProviderEngine {
     super(options);
     this.addProvider(new DefaultFixtures());
     this.addProvider(new NonceTrackerSubprovider());
+    this.addProvider(new TransactionValidatorSubprovider());
     this.addProvider(new SanitizingSubprovider());
     this.addProvider(new CacheSubprovider());
 

--- a/packages/provider/src/subproviders/nonce-tracker.ts
+++ b/packages/provider/src/subproviders/nonce-tracker.ts
@@ -1,0 +1,95 @@
+import Subprovider from 'web3-provider-engine/subproviders/subprovider';
+
+/**
+ * A subprovider that tracks and automatically increments the nonce on the client.
+ * Heavily based on the provider-engine NonceTrackerSubprovider, but modified for
+ * Bitski's transaction flow.
+ */
+export class NonceTrackerSubprovider extends Subprovider {
+
+  protected nonceCache: Map<string, string>;
+
+  constructor() {
+    super();
+    this.nonceCache = new Map<string, string>();
+  }
+
+  public handleRequest(payload, next, end) {
+    switch (payload.method) {
+      case 'eth_getTransactionCount':
+        this.handleTransactionCountRequest(payload, next, end);
+        return;
+      case 'eth_sendTransaction':
+        this.handleSendTransactionRequest(payload, next);
+        return;
+    }
+  }
+
+  // Return cached result if present
+  protected handleTransactionCountRequest(payload, next, end) {
+    const blockTag = payload.params.length > 1 ? payload.params[1] : null;
+    // Only handle pending tag
+    if (blockTag !== 'pending') {
+      next();
+      return;
+    }
+
+    const address = payload.params[0].toLowerCase();
+    const cachedResult = this.nonceCache.get(address);
+
+    // Return cached result it we have it
+    if (cachedResult) {
+      end(null, cachedResult);
+      return;
+    }
+
+    // Fallthrough and populate cache
+    next((err, result, cb) => {
+      if (!err) {
+        this.nonceCache.set(address, result);
+      }
+      cb();
+    });
+  }
+
+  protected toHex(num: number): string {
+    const base16 = num.toString(16);
+    let hex = base16;
+    if (base16.length % 2 !== 0) {
+      hex = '0' + base16;
+    }
+    return '0x' + hex;
+  }
+
+  protected fromHex(str: string): number {
+    return parseInt(str, 16);
+  }
+
+  protected nextNonce(nonce: string): string {
+    const submittedNonce = this.fromHex(nonce);
+    const nextNonce = submittedNonce + 1;
+    return this.toHex(nextNonce);
+  }
+
+  // Increment next nonce for address
+  protected handleSendTransactionRequest(payload, next) {
+    // Submit the request, then monitor the result
+    next((err, result, cb) => {
+      const transaction = payload.params.length > 0 ? payload.params[0] : {};
+      const submittedNonce = transaction.nonce;
+      const address = transaction.from;
+      if (!err) {
+        if (submittedNonce && address) {
+          // Increment nonce
+          const nextNonce = this.nextNonce(submittedNonce);
+          this.nonceCache.set(address, nextNonce);
+        }
+      } else {
+        // Remove cached value if we encounter an error
+        this.nonceCache.delete(address);
+      }
+      cb();
+    });
+  }
+
+}

--- a/packages/provider/src/subproviders/transaction-validator.ts
+++ b/packages/provider/src/subproviders/transaction-validator.ts
@@ -1,0 +1,81 @@
+import Subprovider from 'web3-provider-engine/subproviders/subprovider';
+
+/**
+ * A subprovider that automatically populates missing transaction details.
+ * This is needed because it has become common to submit transactions with
+ * only some of the parameters and rely on the provider or node to fill in the rest.
+ */
+export class TransactionValidatorSubprovider extends Subprovider {
+
+  public handleRequest(payload, next, end) {
+    // Only handle eth_sendTransaction
+    if (payload.method === 'eth_sendTransaction') {
+      this.populateTransactionFields(payload).then((updated) => {
+        next();
+      }).catch(() => {
+        // Fall through if we cannot populate fields
+        next();
+      });
+    } else {
+      next();
+    }
+  }
+
+  // Examine transaction and populate missing params
+  protected populateTransactionFields(payload): Promise<any> {
+    const params = payload.params || [];
+
+    let transaction: any = {};
+
+    if (params.length > 0) {
+      transaction = params[0];
+    }
+
+    const promises: Array<Promise<any>> = [];
+
+    if (transaction.gasPrice === undefined) {
+      const getGasPrice = { method: 'eth_gasPrice', params: []};
+      promises.push(this.performRequest(getGasPrice));
+    } else {
+      promises.push(transaction.gasPrice);
+    }
+
+    if (transaction.nonce === undefined) {
+      const getNextNonce = { method: 'eth_getTransactionCount', params: [transaction.from, 'pending']};
+      promises.push(this.performRequest(getNextNonce));
+    } else {
+      promises.push(transaction.nonce);
+    }
+
+    if (transaction.gas === undefined) {
+      const estimateGas = { method: 'eth_estimateGas', params: [transaction] };
+      promises.push(this.performRequest(estimateGas));
+    } else {
+      promises.push(transaction.gas);
+    }
+
+    return Promise.all(promises).then((values) => {
+      // Update parameters with loaded values
+      transaction.gasPrice = values[0];
+      transaction.nonce = values[1];
+      transaction.gas = values[2];
+      // Set the params on the payload
+      payload.params[0] = transaction;
+      return payload;
+    });
+  }
+
+    // Wraps emitPayload in a promise
+    protected performRequest(payload): Promise<any> {
+      return new Promise((fulfill, reject) => {
+        this.emitPayload(payload, (err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            fulfill(result.result);
+          }
+        });
+      });
+    }
+
+}

--- a/packages/provider/tests/nonce-tracker.test.ts
+++ b/packages/provider/tests/nonce-tracker.test.ts
@@ -1,0 +1,83 @@
+import Web3ProviderEngine from 'web3-provider-engine';
+import { NonceTrackerSubprovider } from '../src/subproviders/nonce-tracker';
+import FixtureSubprovider from 'web3-provider-engine/subproviders/fixture';
+
+function createEngine() {
+  const engine = new Web3ProviderEngine();
+  const provider = new NonceTrackerSubprovider();
+  engine.addProvider(provider);
+  // @ts-ignore
+  engine._ready.go();
+  return { engine, provider };
+}
+
+test('it forwards requests when cache is empty', (done) => {
+  const { engine, provider } = createEngine();
+
+  engine.addProvider(new FixtureSubprovider({
+    eth_getTransactionCount: '0x0',
+  }));
+
+  const request = {
+    id: 1,
+    jsonrpc: '2.0',
+    method: 'eth_getTransactionCount',
+    params: ['0xf00', 'pending'],
+  };
+
+  engine.sendAsync(request, (err, result) => {
+    console.log(result);
+    expect(result.result).toBe('0x0');
+    expect(err).toBeNull();
+    expect(provider.nonceCache.get('0xf00')).toBe('0x0');
+    done();
+  });
+});
+
+test('it responds from cache when cache is present', (done) => {
+  const { engine, provider } = createEngine();
+
+  const request = {
+    id: 1,
+    jsonrpc: '2.0',
+    method: 'eth_getTransactionCount',
+    params: ['0xf00', 'pending'],
+  };
+
+  provider.nonceCache.set('0xf00', '0x01');
+
+  engine.sendAsync(request, (err, result) => {
+    console.log(result);
+    expect(result.result).toBe('0x01');
+    expect(err).toBeNull();
+    expect(provider.nonceCache.get('0xf00')).toBe('0x01');
+    done();
+  });
+});
+
+test('it updates nonce when transaction is successful', (done) => {
+  const { engine, provider } = createEngine();
+
+  engine.addProvider(new FixtureSubprovider({
+    eth_sendTransaction: '0xf00',
+  }));
+
+  provider.nonceCache.set('0xf00', '0x00');
+
+  const request = {
+    id: 1,
+    jsonrpc: '2.0',
+    method: 'eth_sendTransaction',
+    params: [{
+      amount: '0x0',
+      from: '0xf00',
+      nonce: '0x01',
+    }],
+  };
+
+  engine.sendAsync(request, (err, result) => {
+    expect(err).toBeNull();
+    expect(provider.nonceCache.get('0xf00')).toBe('0x02');
+    done();
+  });
+}

--- a/packages/provider/tests/transaction-validator.test.ts
+++ b/packages/provider/tests/transaction-validator.test.ts
@@ -1,0 +1,108 @@
+import Web3ProviderEngine from 'web3-provider-engine';
+import { TransactionValidatorSubprovider } from '../src/subproviders/transaction-validator';
+import FixtureSubprovider from 'web3-provider-engine/subproviders/fixture';
+
+function createEngine() {
+  const engine = new Web3ProviderEngine();
+  const provider = new TransactionValidatorSubprovider();
+  engine.addProvider(provider);
+  engine._ready.go();
+  return { engine, provider };
+}
+
+class MockFixtureProvider extends FixtureSubprovider {
+
+  // Callback is called when we handle any request to inspect the payload
+  public callback: (payload: any) => void;
+
+  constructor(fixtures, callback) {
+    super(fixtures);
+    this.callback = callback;
+  }
+
+  public handleRequest(payload, next, end) {
+    this.callback(payload);
+    super.handleRequest(payload, next, end);
+  }
+}
+
+test('it updates missing values', (done) => {
+  expect.assertions(5);
+
+  const { engine, provider } = createEngine();
+
+  const fixtures = {
+    eth_estimateGas: '0x01',
+    eth_gasPrice: '0x0001',
+    eth_getTransactionCount: '0x0',
+    eth_sendTransaction: '0x1',
+  };
+
+  const assertionsCallback = (payload) => {
+    if (payload.method === 'eth_sendTransaction') {
+      expect(payload.params[0]).toBeDefined();
+      expect(payload.params[0].gas).toBe(fixtures.eth_estimateGas);
+      expect(payload.params[0].gasPrice).toBe(fixtures.eth_gasPrice);
+      expect(payload.params[0].nonce).toBe(fixtures.eth_getTransactionCount);
+    }
+  };
+
+  engine.addProvider(new MockFixtureProvider(fixtures, assertionsCallback));
+
+  const request = {
+    id: 1,
+    jsonrpc: '2.0',
+    method: 'eth_sendTransaction',
+    params: [{
+      amount: '0x0',
+      from: '0xf00',
+    }],
+  };
+
+  engine.sendAsync(request, (err, result) => {
+    expect(err).toBeNull();
+    done();
+  });
+
+});
+
+test('it only updates values that are missing', (done) => {
+  expect.assertions(5);
+
+  const { engine, provider } = createEngine();
+
+  const fixtures = {
+    eth_estimateGas: '0x01',
+    eth_gasPrice: '0x0001',
+    eth_getTransactionCount: '0x0',
+    eth_sendTransaction: '0x1',
+  };
+
+  const assertionsCallback = (payload) => {
+    if (payload.method === 'eth_sendTransaction') {
+      expect(payload.params[0]).toBeDefined();
+      expect(payload.params[0].gas).toBe(fixtures.eth_estimateGas);
+      expect(payload.params[0].gasPrice).toBe(fixtures.eth_gasPrice);
+      expect(payload.params[0].nonce).toBe('0xff');
+    }
+  };
+
+  engine.addProvider(new MockFixtureProvider(fixtures, assertionsCallback));
+
+  const request = {
+    id: 1,
+    jsonrpc: '2.0',
+    method: 'eth_sendTransaction',
+    params: [{
+      amount: '0x0',
+      from: '0xf00',
+      nonce: '0xff',
+    }],
+  };
+
+  engine.sendAsync(request, (err, result) => {
+    expect(err).toBeNull();
+    done();
+  });
+
+});

--- a/packages/provider/types/web3-provider-engine.d.ts
+++ b/packages/provider/types/web3-provider-engine.d.ts
@@ -39,6 +39,20 @@ declare module "web3-provider-engine" {
     export = Web3ProviderEngine;
 }
 
+declare module "web3-provider-engine/subproviders/subprovider" {
+    import { JSONRPCRequestPayload, JSONRPCResponsePayload } from "ethereum-protocol";
+    import Web3ProviderEngine from "web3-provider-engine";
+
+    class Subprovider {
+        engine?: Web3ProviderEngine;
+        setEngine(engine: Web3ProviderEngine);
+        handleRequest(payload: JSONRPCRequestPayload, next: () => void, end: () => void);
+        emitPayload(payload: JSONRPCRequestPayload, callback: (error: null | Error, response: JSONRPCResponsePayload) => void);
+    }
+
+    export = Subprovider;
+}
+
 // declare module "web3-provider-engine/subproviders/nonce-tracker";
 // declare module "web3-provider-engine/subproviders/hooked-wallet";
 // declare module "web3-provider-engine/subproviders/filters";


### PR DESCRIPTION
This adds some features to our provider that we were missing due to our custom transaction flow. Namely, it fills in the nonce, gas, and gasPrice locally, and tracks the nonce.

The motivation for this change was to enable multi-step truffle migrations since truffle migrate does not fill in nonce, and the server does not always have all of the context as it is split across multiple nodes using a load balancer.