### PR TITLE
Submit transaction payloads via API

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -181,6 +181,15 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+    },
+    "@types/uuid": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+      "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "10.3.2"
+      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -7134,7 +7143,7 @@
         "safe-buffer": "5.1.2",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       }
     },
     "request-promise-core": {
@@ -8962,9 +8971,9 @@
       }
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -22,10 +22,12 @@
   "dependencies": {
     "@openid/appauth": "^1.2.0",
     "bitski-provider": "^0.4.2",
+    "uuid": "^3.3.2",
     "web3-provider-engine": "^14.1.0"
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",
+    "@types/uuid": "^3.4.4",
     "babel-preset-es2015": "^6.24.1",
     "browserify": "^16.2.3",
     "jest": "^23.6.0",

--- a/packages/browser/src/auth/oauth-manager.ts
+++ b/packages/browser/src/auth/oauth-manager.ts
@@ -16,6 +16,7 @@ import {
 } from '@openid/appauth';
 import { BITSKI_USER_API_HOST, DEFAULT_OAUTH_CONFIGURATION, DEFAULT_OPTIONAL_SCOPES, DEFAULT_SCOPES } from '../constants';
 import { NoHashQueryStringUtils } from '../utils/no-hash-query-string-utils';
+import { parseResponse } from '../utils/request-utils';
 import { PopupRequestHandler } from './popup-handler';
 import { UserInfoResponse } from './user';
 
@@ -141,7 +142,7 @@ export class OAuthManager {
         },
         method: 'POST',
     }).then((response) => {
-        return this.parseResponse(response);
+        return parseResponse<any>(response);
     });
   }
 
@@ -160,31 +161,7 @@ export class OAuthManager {
         Authorization: `Bearer ${accessToken}`,
       },
     }).then((response) => {
-      return this.parseResponse(response);
-    }).then((parsed) => {
-      return parsed as UserInfoResponse;
-    });
-  }
-
-  /**
-   * Parses a Fetch Response to extract either the result or the error
-   * @param response the fetch response to parse
-   */
-  protected parseResponse(response: Response): Promise<any> {
-    return response.json().catch((jsonParseError) => {
-      throw new Error('Unknown error. Could not parse error response');
-    }).then((json) => {
-      if (response.status >= 200 && response.status < 300) {
-          return json;
-      } else {
-        if (json && json.error && json.error.message) {
-            throw new Error(json.error.message);
-        } else if (json && json.error) {
-            throw new Error(json.error);
-        } else {
-            throw new Error('Unknown error');
-        }
-      }
+      return parseResponse<UserInfoResponse>(response);
     });
   }
 

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -3,8 +3,10 @@ export const SDK_VERSION = '0.4.1';
 
 // URLs
 export const BITSKI_USER_API_HOST = 'https://www.bitski.com/v1';
+export const BITSKI_TRANSACTION_API_BASE_URL = 'https://api.bitski.com/v1';
 export const BITSKI_RPC_BASE_URL = 'https://api.bitski.com/v1/web3';
 export const BITSKI_WEB_BASE_URL = 'https://sign.bitski.com';
+export const IFRAME_MESSAGE_ORIGIN_INCLUDES = '.bitski.com';
 
 // OAuth
 export const DEFAULT_OAUTH_CONFIGURATION = {
@@ -27,4 +29,4 @@ export const USER_KEY = 'bitski.user';
 
 // Methods
 export const CACHED_METHODS = ['eth_accounts'];
-export const DEFAULT_AUTHORIZED_METHODS = ['eth_sendTransaction', 'eth_sign', 'eth_signTypedData', 'personal_sign'];
+export const DEFAULT_AUTHORIZED_METHODS = ['eth_sendTransaction', 'eth_signTransaction', 'eth_sign', 'personal_sign'];

--- a/packages/browser/src/providers/bitski-browser-engine.ts
+++ b/packages/browser/src/providers/bitski-browser-engine.ts
@@ -1,6 +1,6 @@
-import { AccessTokenProvider, AuthenticatedFetchSubprovider, BitskiEngine } from 'bitski-provider';
+import { AccessTokenProvider, AuthenticatedFetchSubprovider, BitskiEngine, Network } from 'bitski-provider';
 import { AuthProvider } from '../auth/auth-provider';
-import { BITSKI_RPC_BASE_URL, BITSKI_WEB_BASE_URL } from '../constants';
+import { BITSKI_RPC_BASE_URL, BITSKI_TRANSACTION_API_BASE_URL, BITSKI_WEB_BASE_URL } from '../constants';
 import { AuthenticatedCacheSubprovider } from '../subproviders/authenticated-cache';
 import { IFrameSubprovider } from '../subproviders/iframe';
 
@@ -11,9 +11,9 @@ function isAuthProvider(object: any): object is AuthProvider {
 
 export class BitskiBrowserEngine extends BitskiEngine {
 
-  private networkName: string;
-  private rpcUrl: string;
+  private network: Network;
   private webBaseUrl: string;
+  private apiBaseUrl: string;
   private tokenProvider: AccessTokenProvider;
   private clientId: string;
   private sdkVersion: string;
@@ -22,13 +22,13 @@ export class BitskiBrowserEngine extends BitskiEngine {
     clientId: string,
     tokenProvider: AccessTokenProvider,
     sdkVersion: string,
-    networkName?: string,
+    network: Network,
     webBaseUrl?: string,
-    rpcUrl?: string,
+    apiBaseUrl?: string,
     options?: any) {
     super(options);
-    this.networkName = networkName || 'mainnet';
-    this.rpcUrl = rpcUrl || `${BITSKI_RPC_BASE_URL}/${this.networkName}`;
+    this.network = network;
+    this.apiBaseUrl = apiBaseUrl || BITSKI_TRANSACTION_API_BASE_URL;
     this.tokenProvider = tokenProvider;
     this.clientId = clientId;
     this.webBaseUrl = webBaseUrl || BITSKI_WEB_BASE_URL;
@@ -50,7 +50,7 @@ export class BitskiBrowserEngine extends BitskiEngine {
       'X-CLIENT-VERSION': this.sdkVersion,
     };
     const fetchSubprovider = new AuthenticatedFetchSubprovider(
-      this.rpcUrl,
+      this.network.rpcUrl,
       false,
       this.tokenProvider,
       defaultHeaders,
@@ -63,7 +63,7 @@ export class BitskiBrowserEngine extends BitskiEngine {
     }
 
     // Respond to requests that need approval with an iframe
-    const iframeSubprovider = new IFrameSubprovider(this.webBaseUrl, this.networkName, this.tokenProvider, this.sdkVersion);
+    const iframeSubprovider = new IFrameSubprovider(this.webBaseUrl, this.apiBaseUrl, this.network.chainId, this.tokenProvider, defaultHeaders);
     this.addProvider(iframeSubprovider);
 
     // Finally, add our basic fetch provider

--- a/packages/browser/src/subproviders/authorization-handler.ts
+++ b/packages/browser/src/subproviders/authorization-handler.ts
@@ -6,6 +6,7 @@ import { DEFAULT_AUTHORIZED_METHODS } from '../constants';
 export abstract class AuthorizationHandler extends Subprovider {
 
   protected authorizedMethods: string[];
+  protected next?: () => void;
 
   constructor(opts?: any) {
     super();
@@ -14,13 +15,21 @@ export abstract class AuthorizationHandler extends Subprovider {
 
   public handleRequest(payload, next, end): void {
     if (this.requiresAuthorization(payload.method)) {
-      this.handleAuthorization(payload, next, end);
+      this.next = next;
+      this.handleAuthorization(payload, end);
       return;
     }
     next();
   }
 
-  public abstract handleAuthorization(payload, next, end): void;
+  public abstract handleAuthorization(payload, callback): void;
+
+  protected skip() {
+    if (this.next) {
+      this.next();
+      this.next = undefined;
+    }
+  }
 
   protected requiresAuthorization(method: string): boolean {
     return this.authorizedMethods.includes(method);

--- a/packages/browser/src/subproviders/iframe.ts
+++ b/packages/browser/src/subproviders/iframe.ts
@@ -1,121 +1,237 @@
-import { AccessTokenProvider } from 'bitski-provider';
+import { AccessTokenProvider, JSONRPCRequestPayload } from 'bitski-provider';
 import JsonRpcError from 'json-rpc-error';
-import createPayload from 'web3-provider-engine/util/create-payload';
+import uuid from 'uuid';
 import { Dialog } from '../components/dialog';
+import { IFRAME_MESSAGE_ORIGIN_INCLUDES } from '../constants';
+import { parseResponse } from '../utils/request-utils';
 import { AuthorizationHandler } from './authorization-handler';
 
-type Request = [any, any];
+type Request = [JSONRPCRequestPayload, JSONRPCResponseHandler];
+type JSONRPCResponseHandler = (error?: JsonRpcError, result?: any) => void;
+
+interface TransactionRequest {
+  transaction: Transaction;
+}
+
+export enum TransactionKind {
+  SendTransaction = 'ETH_SEND_TRANSACTION',
+  SignTransaction = 'ETH_SIGN_TRANSACTION',
+  Sign = 'ETH_SIGN',
+}
+
+export interface Transaction {
+  id: string;
+  kind: TransactionKind;
+  payload: TransactionPayload | SignaturePayload;
+  context: TransactionContext;
+}
+
+export interface TransactionContext {
+  chainId: number;
+}
+
+export interface SignaturePayload {
+  from: string;
+  message: string;
+}
+
+export interface TransactionPayload {
+  from: string;
+  to?: string;
+  value?: string;
+  data?: string;
+  nonce?: string;
+  gas?: string;
+  gasPrice?: string;
+}
 
 /*
  * An AuthorizationHandler Subprovider that uses an iframe to get authorization from the user.
  */
 export class IFrameSubprovider extends AuthorizationHandler {
-    public currentRequestDialog?: Dialog;
-    private webBaseUrl: string;
-    private networkName: string;
-    private tokenProvider: AccessTokenProvider;
-    private currentRequest?: Request;
-    private sdkVersion: string;
+  protected webBaseUrl: string;
+  protected apiBaseUrl: string;
+  protected chainId: number;
+  protected tokenProvider: AccessTokenProvider;
+  protected defaultHeaders: any;
 
-    constructor(webBaseUrl: string, networkName: string, tokenProvider: AccessTokenProvider, sdkVersion: string) {
-        super();
-        this.webBaseUrl = webBaseUrl;
-        this.networkName = networkName;
-        this.tokenProvider = tokenProvider;
-        this.sdkVersion = sdkVersion;
-        window.addEventListener('message', this.receiveMessage.bind(this), false);
+  private currentRequestDialog?: Dialog;
+  private currentRequest?: Request;
+
+  constructor(webBaseUrl: string, apiBaseUrl: string, chainId: number, tokenProvider: AccessTokenProvider, defaultHeaders: any = {}) {
+    super();
+    this.webBaseUrl = webBaseUrl;
+    this.chainId = chainId;
+    this.tokenProvider = tokenProvider;
+    this.apiBaseUrl = apiBaseUrl;
+    this.defaultHeaders = defaultHeaders;
+    window.addEventListener('message', this.receiveMessage.bind(this), false);
+  }
+
+  /**
+   * Called when a payload is received that needs authorization
+   * @param payload The JSON-RPC request
+   * @param callback The callback to call when the request has been handled
+   */
+  public handleAuthorization(payload: JSONRPCRequestPayload, callback: JSONRPCResponseHandler): void {
+    this.tokenProvider.getAccessToken().then((accessToken) => {
+      const transaction = this.createBitskiTransaction(payload);
+      return this.submitTransaction(transaction, accessToken).then((persistedTransaction) => {
+        this.showAuthorizationModal(persistedTransaction.transaction, [payload, callback]);
+      });
+    }).catch((error) => {
+      callback(error, undefined);
+    });
+  }
+
+  /**
+   * Event listener for callbacks from the iframe
+   * @param event MessageEvent received from the browser
+   */
+  public receiveMessage(event: MessageEvent): void {
+    if (!event.origin.includes(IFRAME_MESSAGE_ORIGIN_INCLUDES)) {
+      return;
     }
 
-    public handleAuthorization(payload, _, end): void {
-        this.tokenProvider.getAccessToken().then((accessToken) => {
-            this.showBitskiModal(accessToken, payload, end);
-        }).catch((error) => {
-            end(error, undefined);
-        });
+    const data = event.data;
+
+    // Ignore message events that don't actually have data
+    if (data === undefined || data === null) {
+      return;
     }
 
-    public receiveMessage(event: MessageEvent): void {
-        if (!event.origin.includes('bitski.com')) {
-            return;
-        }
-
-        const data = event.data;
-
-        if (data === undefined || data === null) {
-            return;
-        }
-
-        if (this.currentRequest === undefined) {
-            return;
-        }
-
-        const payload = this.currentRequest[0];
-
-        if (typeof payload.id === 'number' && payload.id !== data.id) {
-            return;
-        }
-
-        if (this.currentRequestDialog) {
-            this.currentRequestDialog.dismiss();
-            this.currentRequestDialog = undefined;
-        }
-
-        const end = this.currentRequest[1];
-        end(data.error, data.result);
+    // Ignore messages when we don't have a current request in flight
+    if (this.currentRequest === undefined) {
+      return;
     }
 
-    private urlForMethod(method: string): string | undefined {
-        // TODO: Other methods
-        switch (method) {
-        case 'eth_sendTransaction':
-            return this.webBaseUrl + '/eth-send-transaction';
-        case 'eth_sign':
-        case 'personal_sign':
-            return this.webBaseUrl + '/eth-sign';
-        default:
-            return undefined;
-        }
+    const [_, callback] = this.currentRequest;
+
+    // Dismiss current dialog
+    if (this.currentRequestDialog) {
+      this.currentRequestDialog.dismiss();
     }
 
-    // Show the real transaction modal when using a bitski wallet
-    private showBitskiModal(accessToken, payload, end) {
-        const authorizationUrl = this.urlForMethod(payload.method);
+    // Call the callback to complete the request
+    callback(data.error, data.result);
 
-        if (authorizationUrl === undefined) {
-            end(new JsonRpcError.InternalError(), undefined);
-            return;
-        }
+    // Clear state
+    this.currentRequest = undefined;
+    this.currentRequestDialog = undefined;
+  }
 
-        const newPayload = createPayload(payload);
-        const encodedPayload = btoa(JSON.stringify(newPayload));
-        const txnParams = `sdkVersion=${this.sdkVersion}&network=${this.networkName}&payload=${encodedPayload}&referrerAccessToken=${accessToken}`;
+  /**
+   * Responsible for creating the Transaction object from a given RPC payload
+   * @param payload JSON-RPC payload to extract the values from
+   */
+  protected createBitskiTransaction(payload: JSONRPCRequestPayload): Transaction {
+    const context = { chainId: this.chainId } as TransactionContext;
+    const kind = this.kindForMethod(payload.method);
+    const transactionPayload = this.createPayload(payload);
+    const transaction = {
+      id: uuid(),
+      kind,
+      payload: transactionPayload,
+      context,
+    };
+    return transaction as Transaction;
+  }
 
-        const iframe = document.createElement('iframe');
-        iframe.style.position = 'absolute';
-        iframe.style.top = '0';
-        iframe.style.left = '0';
-        iframe.style.width = '100%';
-        iframe.style.height = '100%';
-        iframe.frameBorder = '0';
-        iframe.src = `${authorizationUrl}?${txnParams}`;
+  /**
+   * Responsible for submitting the Transaction object to the API
+   * @param transaction The Transaction object to submit
+   * @param accessToken The current user's access token
+   */
+  protected submitTransaction(transaction: Transaction, accessToken: string): Promise<TransactionRequest> {
+    const requestBody = { transaction };
+    const headers = Object.assign({}, this.defaultHeaders, {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    });
+    return fetch(`${this.apiBaseUrl}/transactions`, {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+      headers,
+    }).then((response) => {
+      return parseResponse<TransactionRequest>(response);
+    });
+  }
 
-        this.showAuthorizationModal(iframe, payload, end);
+  /**
+   * Displays the authorization form in a modal window
+   * @param transaction The transaction that has been submitted
+   * @param request The request and callback pair associated with this transaction
+   */
+  protected showAuthorizationModal(transaction: Transaction, request: Request) {
+    const url = `${this.webBaseUrl}/transactions/${transaction.id}`;
+
+    const iframe = document.createElement('iframe');
+    iframe.style.position = 'absolute';
+    iframe.style.top = '0';
+    iframe.style.left = '0';
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+    iframe.frameBorder = '0';
+    iframe.src = url;
+
+    // Dismiss any existing dialogs to prevent UI glitches.
+    if (this.currentRequestDialog) {
+      this.currentRequestDialog.close();
     }
 
-    private showAuthorizationModal(element, payload, end) {
-        if (this.currentRequestDialog) {
-            this.currentRequestDialog.dismiss();
-        }
+    this.currentRequest = request;
+    this.currentRequestDialog = new Dialog(iframe, true);
+    this.currentRequestDialog.onClose = () => {
+      const [_, callback] = request;
+      callback(new Error('The transaction was cancelled'), undefined);
+    };
+  }
 
-        if (this.currentRequest) {
-            const oldTransactionEnd = this.currentRequest[1];
-            oldTransactionEnd(new JsonRpcError.InternalError(), undefined);
+  /**
+   * Responsible for creating the payload from a given RPC request
+   * @param request JSON-RPC request to extract params from
+   */
+  private createPayload(request: JSONRPCRequestPayload): TransactionPayload | SignaturePayload {
+    switch (request.method) {
+      case 'eth_sendTransaction':
+      case 'eth_signTransaction':
+        if (request.params && request.params.length > 0) {
+          return request.params[0] as TransactionPayload;
+        } else {
+          throw new Error('Invalid request: Could not find transaction values.');
         }
-
-        this.currentRequest = [payload, end];
-        this.currentRequestDialog = new Dialog(element, true);
-        this.currentRequestDialog.onClose = () => {
-            end(new Error('The transaction was cancelled'), undefined);
-        };
+      case 'eth_sign':
+        if (request.params && request.params.length > 1) {
+          return { from: request.params[0], message: request.params[1] };
+        } else {
+          throw new Error('Invalid request: Could not find params for signature.');
+        }
+      case 'personal_sign':
+        if (request.params && request.params.length > 1) {
+          return { from: request.params[1], message: request.params[0] };
+        } else {
+          throw new Error('Invalid request: Could not find params for signature.');
+        }
+      default:
+        throw new Error('Method not supported');
     }
+  }
+
+  /**
+   * Determines a BitskiTransaction.Kind value from a given RPC method name
+   * @param method The JSON-RPC method being requested
+   */
+  private kindForMethod(method: string): TransactionKind {
+    switch (method) {
+      case 'eth_sendTransaction':
+        return TransactionKind.SendTransaction;
+      case 'eth_signTransaction':
+        return TransactionKind.SignTransaction;
+      case 'eth_sign':
+      case 'personal_sign':
+        return TransactionKind.Sign;
+      default:
+        throw new Error('Method not supported');
+    }
+  }
 }

--- a/packages/browser/src/subproviders/local-dialog.ts
+++ b/packages/browser/src/subproviders/local-dialog.ts
@@ -17,18 +17,18 @@ export class LocalDialogSubprovider extends AuthorizationHandler {
       super(opts);
   }
 
-  public handleAuthorization(payload, next, end): void {
-    this.showTransactionModal(payload, next, end);
+  public handleAuthorization(payload, end): void {
+    this.showTransactionModal(payload, end);
   }
 
-  private showTransactionModal(payload, next, end) {
+  private showTransactionModal(payload, end) {
 
       const submitHandler = () => {
-        next();
         this.currentRequest = undefined;
         if (this.currentDialog) {
             this.currentDialog.dismiss();
         }
+        this.skip();
       };
 
       const cancelHandler = () => {

--- a/packages/browser/src/utils/request-utils.ts
+++ b/packages/browser/src/utils/request-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Parses a Fetch Response to extract either the result or the error
+ * @param response the fetch response to parse
+ */
+export function parseResponse<T>(response: Response): Promise<T> {
+  return response.json().catch(() => {
+    throw new Error('Unknown error. Could not parse error response');
+  }).then((json) => {
+    if (response.status >= 200 && response.status < 300) {
+      return json as T;
+    } else {
+      if (json && json.error && json.error.message) {
+        throw new Error(json.error.message);
+      } else if (json && json.error) {
+      throw new Error(json.error);
+      } else {
+        throw new Error('Unknown error');
+      }
+    }
+  });
+}

--- a/packages/browser/tests/auth-provider.test.ts
+++ b/packages/browser/tests/auth-provider.test.ts
@@ -1,5 +1,4 @@
 import { TokenResponse } from '@openid/appauth';
-import mock from 'xhr-mock';
 import { AccessToken } from '../src/auth/access-token';
 import { OpenidAuthProvider } from '../src/auth/openid-auth-provider';
 import { TokenStore } from '../src/auth/token-store';
@@ -37,14 +36,12 @@ beforeEach(() => {
   if (localStorage) {
     localStorage.clear();
   }
-  mock.setup();
 });
 
 afterEach(() => {
   if (localStorage) {
     localStorage.clear();
   }
-  mock.teardown();
 });
 
 describe('getAuthStatus', () => {

--- a/packages/browser/tests/authenticated-cache.test.ts
+++ b/packages/browser/tests/authenticated-cache.test.ts
@@ -34,6 +34,36 @@ describe('authorization handler', () => {
     provider.handleRequest(payload, next, end);
   });
 
+  test('it forwards calls when no cached data is undefined', (done) => {
+    const authProvider = createAuthProvider();
+
+    // getUser will return undefined
+    const getUserSpy = jest.spyOn(authProvider, 'getUser');
+    getUserSpy.mockResolvedValue(undefined);
+
+    const provider = new AuthenticatedCacheSubprovider(authProvider);
+
+    const payload = {
+      id: 0,
+      jsonrpc: '2.0',
+      method: 'eth_accounts',
+      params: [],
+    };
+
+    // @ts-ignore
+    jest.spyOn(provider, 'checkCachedValues').mockResolvedValue(undefined);
+
+    const next = () => {
+      done();
+    };
+
+    const end = (error, value) => {
+      done.fail('end() should not be called');
+    };
+
+    provider.handleRequest(payload, next, end);
+  });
+
   test('it forwards calls when no cached data is available', (done) => {
     const authProvider = createAuthProvider();
 

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -15,7 +15,15 @@ describe('managing providers', () => {
     const provider = bitski.getProvider();
     expect(provider).toBeDefined();
     // @ts-ignore
-    expect(provider.rpcUrl.includes('mainnet')).toBe(true);
+    expect(provider.network.name).toBe('mainnet');
+  });
+
+  test('should get a mainnet provider when passing options with no network name', () => {
+    const bitski = createInstance();
+    const provider = bitski.getProvider({ pollingInterval: 1000000 });
+    expect(provider).toBeDefined();
+    // @ts-ignore
+    expect(provider.network.name).toBe('mainnet');
   });
 
   test('should be able to pass a network name as a string', () => {
@@ -23,7 +31,7 @@ describe('managing providers', () => {
     const provider = bitski.getProvider('rinkeby');
     expect(provider).toBeDefined();
     // @ts-ignore
-    expect(provider.rpcUrl.includes('rinkeby')).toBe(true);
+    expect(provider.network.name).toBe('rinkeby');
   });
 
   test('should be able to pass a network name in options', () => {
@@ -31,7 +39,12 @@ describe('managing providers', () => {
     const provider = bitski.getProvider({ networkName: 'rinkeby' });
     expect(provider).toBeDefined();
     // @ts-ignore
-    expect(provider.rpcUrl.includes('rinkeby')).toBe(true);
+    expect(provider.network.name).toBe('rinkeby');
+  });
+
+  test('passing an invalid network name results in an error', () => {
+    const bitski = createInstance();
+    expect(() => { bitski.getProvider('ropstem'); }).toThrow(/Unsupported network/);
   });
 
   test('should be able to pass a rpcUrl in options', () => {
@@ -45,17 +58,20 @@ describe('managing providers', () => {
   test('should be able to pass in custom configuration', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider({
-      networkName: 'rinkeby',
-      rpcUrl: 'https://api-v2.bitski.com/web3/rinkeby',
+      network: {
+        name: 'rinkeby',
+        rpcUrl: 'https://api-v2.bitski.com/web3/rinkeby',
+        chainId: 4,
+      },
       webBaseUrl: 'https://next.bitski.com',
     });
     expect(provider).toBeDefined();
     // @ts-ignore
-    expect(provider.networkName).toBe('rinkeby');
+    expect(provider.network.name).toBe('rinkeby');
     // @ts-ignore
     expect(provider.webBaseUrl).toBe('https://next.bitski.com');
     // @ts-ignore
-    expect(provider.rpcUrl).toBe('https://api-v2.bitski.com/web3/rinkeby');
+    expect(provider.network.rpcUrl).toBe('https://api-v2.bitski.com/web3/rinkeby');
   });
 
   test('should pass settings to provider-engine', () => {
@@ -134,6 +150,7 @@ describe('authentication', () => {
     spy.mockReturnValue(AuthenticationStatus.Connected);
     return bitski.getAuthStatus().then((authStatus) => {
       expect(authStatus).toBe(AuthenticationStatus.Connected);
+      expect(authStatus).toBe(bitski.authStatus);
     });
   });
 

--- a/packages/browser/tests/local-dialog.test.ts
+++ b/packages/browser/tests/local-dialog.test.ts
@@ -25,7 +25,7 @@ describe('it handles authorized requests with a local dialog', () => {
         value: '0x0',
       }]);
 
-      instance.handleAuthorization(payload, jest.fn, jest.fn);
+      instance.handleRequest(payload, jest.fn, jest.fn);
       // @ts-ignore
       expect(instance.currentDialog).not.toBeUndefined();
       // @ts-ignore
@@ -45,7 +45,7 @@ describe('it handles authorized requests with a local dialog', () => {
       }]);
       const next = jest.fn();
       const end = jest.fn();
-      instance.handleAuthorization(payload, next, end);
+      instance.handleRequest(payload, next, end);
       // @ts-ignore
       instance.transactionWindow.submit();
       expect(next).toBeCalled();
@@ -65,7 +65,7 @@ describe('it handles authorized requests with a local dialog', () => {
       }]);
       const next = jest.fn();
       const end = jest.fn();
-      instance.handleAuthorization(payload, next, end);
+      instance.handleRequest(payload, next, end);
       // @ts-ignore
       instance.transactionWindow.cancel();
       expect(next).not.toBeCalled();
@@ -94,7 +94,7 @@ describe('it handles authorized requests with a local dialog', () => {
         value: '0x0',
       }]);
 
-      instance.handleAuthorization(payload, jest.fn, jest.fn);
+      instance.handleRequest(payload, jest.fn, jest.fn);
 
       expect(dismissSpy).toBeCalled();
       expect(end).toBeCalled();

--- a/packages/browser/tslint.json
+++ b/packages/browser/tslint.json
@@ -11,7 +11,8 @@
             "options": [160]
         },
         "indent": [true, "spaces", 2],
-        "no-switch-case-fall-through": true
+        "no-switch-case-fall-through": true,
+        "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }

--- a/packages/provider/package-lock.json
+++ b/packages/provider/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski-provider",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -2,3 +2,17 @@ export { BitskiEngine } from './bitski-engine';
 export { AccessToken } from './auth/access-token';
 export { AccessTokenProvider } from './auth/access-token-provider';
 export { AuthenticatedFetchSubprovider } from './subproviders/authenticated-fetch';
+export { Network, Mainnet, Rinkeby, Kovan } from './network';
+
+export interface JSONRPCRequestPayload {
+  params: any[];
+  method: string;
+  id: number;
+  jsonrpc: string;
+}
+
+export interface JSONRPCResponsePayload {
+  result: any;
+  id: number;
+  jsonrpc: string;
+}

--- a/packages/provider/src/network.ts
+++ b/packages/provider/src/network.ts
@@ -1,0 +1,23 @@
+export interface Network {
+  chainId: number;
+  name: string;
+  rpcUrl: string;
+}
+
+export const Mainnet: Network = {
+  chainId: 1,
+  name: 'mainnet',
+  rpcUrl: 'https://api.bitski.com/v1/web3/mainnet',
+};
+
+export const Rinkeby: Network = {
+  chainId: 4,
+  name: 'rinkeby',
+  rpcUrl: 'https://api.bitski.com/v1/web3/rinkeby',
+};
+
+export const Kovan: Network = {
+  chainId: 42,
+  name: 'kovan',
+  rpcUrl: 'https://api.bitski.com/v1/web3/kovan',
+};


### PR DESCRIPTION
We’re moving away from using query params to encode transactions to be displayed to the user.