### PR TITLE
Fix some issues with signOut()

### DIFF
--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -125,15 +125,14 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
     }
 
     public signOut(): Promise<any> {
-        if (this.tokenStore.currentToken) {
-            const token = this.tokenStore.currentToken;
-            this.tokenStore.clear();
-            this.userStore.clear();
-            return this.oauthManager.requestSignOut(token);
-        }
+        this.tokenStore.clear();
+        this.userStore.clear();
+        // Call the sign out callback if one has been provided
         if (this.signOutCallback) {
             this.signOutCallback();
         }
+        // We don't currently have the ability to invalidate access tokens, so for now simply resolve.
+        // Down the road this may perform a network request to invalidate.
         return Promise.resolve();
     }
 

--- a/packages/browser/tests/auth-provider.test.ts
+++ b/packages/browser/tests/auth-provider.test.ts
@@ -339,7 +339,7 @@ describe('sign out', () => {
     });
   });
 
-  test('should request sign out via api', () => {
+  test('should remove user data on sign out', () => {
     expect.assertions(4);
     const authProvider = createInstance();
     (authProvider.tokenStore as MockTokenStore).setToken(dummyToken);
@@ -347,19 +347,10 @@ describe('sign out', () => {
     authProvider.userStore.set(dummyUser);
     const spy = jest.spyOn(authProvider.oauthManager, 'requestSignOut').mockResolvedValue({});
     return authProvider.signOut().then(() => {
-      expect(spy).toHaveBeenCalledWith(dummyToken.token);
+      expect(spy).not.toHaveBeenCalled();
       expect(authProvider.tokenStore.currentToken).toBeUndefined();
       expect(authProvider.tokenStore.refreshToken).toBeUndefined();
       expect(authProvider.userStore.currentUser).toBeUndefined();
-    });
-  });
-
-  test('should resolve silently if not signed in', () => {
-    expect.assertions(1);
-    const authProvider = createInstance();
-    const spy = jest.spyOn(authProvider.oauthManager, 'requestSignOut');
-    return authProvider.signOut().then(() => {
-      expect(spy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes 3 issues:
- Our logout API endpoint is no longer working, so this removes the network error that is visible
- If you don't have a current access token, your user data is not cleared on sign out
- Early return for network request was causing `signOutCallback` to never be called