### PR TITLE
Add support for EthereumProvider spec and new versions of Web3

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.2.0.tgz",
-      "integrity": "sha512-u0qhCJ03MxhXLvbW3CmCRQ1F4Y7ivRzKdrI5W3qllKzZwUYbASl/YqvFn2uiCPWuq2YT9NCekh1ck47lQC6fyg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
+      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",
@@ -79,9 +79,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.0.0.tgz",
-          "integrity": "sha512-LNZ6JSpKraIia6VZKKbKxmX6nWIdfsG7WqrOvKpCuDjH7BnGyQRFMTSXEe8to2WF/rqoAKgZvj+L5nnxe0suAg=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+          "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
         }
       }
     },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -21,7 +21,7 @@
     "prepack": "npm run build && npm run bundle"
   },
   "dependencies": {
-    "@bitski/provider-engine": "^0.2.0",
+    "@bitski/provider-engine": "^0.4.1",
     "@openid/appauth": "^1.2.0",
     "bitski-provider": "^0.6.0",
     "uuid": "^3.3.2"
@@ -33,5 +33,5 @@
     "jest": "^23.6.0",
     "terser": "^3.14.1"
   },
-  "gitHead": "f927467810fc95f498e7284ffae4472f8d4278d9"
+  "gitHead": "712655013208eec20a934aa4d81bcd849f83ee63"
 }

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -10,9 +10,16 @@ function createInstance(): Bitski {
 }
 
 describe('managing providers', () => {
+
+  beforeEach(() => {
+    // This doesn't seem to be working. Instead catching network errors and silencing them.
+    fetch.mockResponse(JSON.stringify({ jsonrpc: '2.0', id: 0, result: null }));
+  });
+
   test('should get a mainnet provider by default', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider();
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network).toBe(Mainnet);
@@ -21,6 +28,7 @@ describe('managing providers', () => {
   test('should get a mainnet provider when passing options with no network name', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider({ pollingInterval: 1000000 });
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network).toBe(Mainnet);
@@ -29,6 +37,7 @@ describe('managing providers', () => {
   test('should be able to pass a network name as a string', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider('rinkeby');
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network).toBe(Rinkeby);
@@ -37,6 +46,7 @@ describe('managing providers', () => {
   test('should be able to pass a network name in options', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider({ networkName: 'rinkeby' });
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network).toBe(Rinkeby);
@@ -55,6 +65,7 @@ describe('managing providers', () => {
         chainId: 0,
       },
     });
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network.rpcUrl).toBe('http://localhost:3000/web3');
@@ -69,6 +80,7 @@ describe('managing providers', () => {
       },
       webBaseUrl: 'https://next.bitski.com',
     });
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.network.chainId).toBe(4);
@@ -81,6 +93,7 @@ describe('managing providers', () => {
   test('should pass settings to provider-engine', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider({ networkName: 'mainnet', pollingInterval: 10000000 });
+    provider.on('error', (error) => {});
     // @ts-ignore
     expect(provider._blockTracker._pollingInterval).toBe(10000000);
   });
@@ -93,6 +106,7 @@ describe('managing providers', () => {
         'X-FOO-FEATURE': 'ENABLED',
       },
     });
+    provider.on('error', (error) => {});
     expect(provider).toBeDefined();
     // @ts-ignore
     expect(provider.headers['X-FOO-FEATURE']).toBe('ENABLED');
@@ -103,6 +117,7 @@ describe('managing providers', () => {
     // @ts-ignore
     expect(bitski.engines.size).toBe(0);
     const provider = bitski.getProvider('kovan');
+    provider.on('error', (error) => {});
     // @ts-ignore
     expect(bitski.engines.size).toBe(1);
   });
@@ -122,6 +137,7 @@ describe('managing providers', () => {
   test('should stop all engines when signing out', () => {
     const bitski = createInstance();
     const provider = bitski.getProvider('kovan');
+    provider.on('error', (error) => {});
     // @ts-ignore
     expect(provider._blockTracker._isRunning).toBe(true);
     bitski.signOut();

--- a/packages/provider/package-lock.json
+++ b/packages/provider/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitski-provider",
-  "version": "0.6.0-alpha.0",
+  "version": "0.6.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.2.0.tgz",
-      "integrity": "sha512-u0qhCJ03MxhXLvbW3CmCRQ1F4Y7ivRzKdrI5W3qllKzZwUYbASl/YqvFn2uiCPWuq2YT9NCekh1ck47lQC6fyg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
+      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",
@@ -79,9 +79,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.0.0.tgz",
-          "integrity": "sha512-LNZ6JSpKraIia6VZKKbKxmX6nWIdfsG7WqrOvKpCuDjH7BnGyQRFMTSXEe8to2WF/rqoAKgZvj+L5nnxe0suAg=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+          "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
         }
       }
     },

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -17,12 +17,11 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@bitski/provider-engine": "^0.2.0",
-    "@types/ethereum-protocol": "^1.0.0",
+    "@bitski/provider-engine": "^0.4.1",
     "json-rpc-error": "^2.0.0"
   },
   "devDependencies": {
     "jest": "^23.6.0"
   },
-  "gitHead": "f927467810fc95f498e7284ffae4472f8d4278d9"
+  "gitHead": "712655013208eec20a934aa4d81bcd849f83ee63"
 }

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -6,7 +6,6 @@ import {
   SanitizerSubprovider,
   SubscriptionSubprovider,
 } from '@bitski/provider-engine';
-import { JSONRPCRequestPayload } from 'ethereum-protocol';
 
 import { NonceTrackerSubprovider } from './subproviders/nonce-tracker';
 import { TransactionValidatorSubprovider } from './subproviders/transaction-validator';
@@ -24,6 +23,8 @@ export class BitskiEngine extends Web3ProviderEngine {
 
   constructor(options?: BitskiEngineOptions) {
     super(options);
+    options = options || {};
+
     // Handles static responses
     this.addProvider(new DefaultFixtureSubprovider());
 
@@ -48,8 +49,10 @@ export class BitskiEngine extends Web3ProviderEngine {
 
     // Handles subscriptions and filters
     const filterAndSubsSubprovider = new SubscriptionSubprovider();
-    filterAndSubsSubprovider.on('data', (err, notification) => {
-      this.emit('data', err, notification);
+
+    // Watch for updates from subscriptions
+    filterAndSubsSubprovider.on('data', (_, notification) => {
+      this.onMessage(notification);
     });
 
     this.addProvider(filterAndSubsSubprovider);
@@ -60,13 +63,30 @@ export class BitskiEngine extends Web3ProviderEngine {
     }
   }
 
-  // Some versions of web3 prefer to use send(payload, callback) instead of sendAsync() with a callback.
-  public send(payload: JSONRPCRequestPayload) {
-    // Typescript doesn't like overrides with overloads, so use arguments array.
-    if (typeof arguments[1] === 'function') {
-      this.sendAsync(payload, arguments[1]);
-    } else {
-      throw new Error('synchronous requests are not supported');
+  public supportsSubscriptions(): boolean {
+    return true;
+  }
+
+  public subscribe(subscribeMethod: string = 'eth_subscribe', subscriptionMethod: string, parameters: any[]): Promise<string> {
+    parameters.unshift(subscriptionMethod);
+    return this.send(subscribeMethod, parameters);
+  }
+
+  public unsubscribe(subscriptionId: string, unsubscribeMethod: string = 'eth_unsubscribe'): Promise<boolean> {
+    return this.send(unsubscribeMethod, [subscriptionId]).then((response) => {
+      if (response) {
+          this.removeAllListeners(subscriptionId);
+      }
+      return response;
+    });
+  }
+
+  protected onMessage(notification) {
+    // Re-emit (previous behavior ~ web3 1.0.0-beta.37)
+    this.emit('data', null, notification);
+    if (notification && notification.params && notification.params.subscription) {
+      // Current web3 behavior - emit subscription id
+      this.emit(notification.params.subscription, notification.params);
     }
   }
 

--- a/packages/provider/tests/authenticated-fetch.test.ts
+++ b/packages/provider/tests/authenticated-fetch.test.ts
@@ -50,16 +50,12 @@ describe('handles authenticated sends', () => {
 
     // @ts-ignore
     const sendRequestSpy = jest.spyOn(provider, 'sendRequest');
-    const request = createRequest('eth_accounts', []);
-    provider.originHttpHeaderKey = 'Origin';
-    request.origin = 'http://foo.bar';
-    return engine.sendAsync(request, (error, value) => {
+    engine.send('eth_accounts', []).then((value) => {
       expect(sendRequestSpy).toHaveBeenCalled();
       const params = sendRequestSpy.mock.calls[0][0];
       expect(params.headers.Authorization).toBe('Bearer test-access-token');
       expect(params.headers['X-API-KEY']).toBe('test-client-id');
-      expect(error).toBeNull();
-      expect(value.result).toBe('foo');
+      expect(value).toBe('foo');
       done();
     });
   });
@@ -70,10 +66,7 @@ describe('handles authenticated sends', () => {
     const engine = createEngine(provider);
     provider.accessTokenProvider.loggedIn = false;
 
-    // @ts-ignore
-    const request = createRequest('eth_accounts', []);
-
-    return engine.sendAsync(request, (error) => {
+    engine.send('eth_accounts', []).catch((error) => {
       expect(error.message).toMatch(/Not logged in/);
       done();
     });
@@ -86,13 +79,9 @@ describe('handles authenticated sends', () => {
     // @ts-ignore
     fetch.once('ECONNRESET', { status: 500 }).once('ECONNRESET', { status: 500 }).once(JSON.stringify({ id: 0, jsonrpc: '2.0', result: 'foo' }));
 
-    // @ts-ignore
-    const request = createRequest('eth_peerCount', []);
-
-    return engine.sendAsync(request, (error, value) => {
+    return engine.send('eth_peerCount', []).then((value) => {
       expect(fetch.mock.calls.length).toBe(3);
-      expect(error).toBeNull();
-      expect(value.result).toBe('foo');
+      expect(value).toBe('foo');
       done();
     });
   });
@@ -104,13 +93,9 @@ describe('handles authenticated sends', () => {
     // @ts-ignore
     fetch.mockResponse(JSON.stringify({ error: { message: 'Not Authorized' }}));
 
-    // @ts-ignore
-    const request = createRequest('eth_peerCount', []);
-
-    return engine.sendAsync(request, (error, value) => {
+    engine.send('eth_peerCount', []).catch((error) => {
       expect(fetch.mock.calls.length).toBe(1);
       expect(error.message).toMatch(/Not Authorized/);
-      expect(value.result).toBeUndefined();
       done();
     });
   });
@@ -124,9 +109,8 @@ describe('handles authenticated sends', () => {
     // @ts-ignore
     const request = createRequest('eth_peerCount', []);
 
-    return engine.sendAsync(request, (error, value) => {
+    return engine.send('eth_peerCount', []).catch((error) => {
       expect(error.message).toMatch(/All retries exhausted/);
-      expect(value.result).toBeUndefined();
       expect(fetch.mock.calls.length).toBe(5);
       done();
     });
@@ -145,15 +129,13 @@ describe('handles authenticated sends', () => {
 
     // @ts-ignore
     const sendRequestSpy = jest.spyOn(provider, 'sendRequest');
-    const request = createRequest('eth_peerCount', []);
 
-    return engine.sendAsync(request, (error, value) => {
+    engine.send('eth_peerCount', []).then((value) => {
       expect(sendRequestSpy).toHaveBeenCalled();
       const params = sendRequestSpy.mock.calls[0][0];
       expect(params.headers.Authorization).toBeUndefined();
       expect(params.headers['X-API-KEY']).toBe('test-client-id');
-      expect(error).toBeNull();
-      expect(value.result).toBe('foo');
+      expect(value).toBe('foo');
       done();
     });
   });
@@ -170,11 +152,11 @@ describe('handles authenticated sends', () => {
       id: 0,
       jsonrpc: '2.0',
     }));
+
     // @ts-ignore
     const invalidateTokenSpy = jest.spyOn(provider.accessTokenProvider, 'invalidateToken');
-    const request = createRequest('eth_peerCount', []);
 
-    return engine.sendAsync(request, (error, value) => {
+    engine.send('eth_peerCount', []).catch((error) => {
       expect(invalidateTokenSpy).toHaveBeenCalled();
       expect(error).toBeDefined();
       done();

--- a/packages/provider/tests/bitski-engine.test.ts
+++ b/packages/provider/tests/bitski-engine.test.ts
@@ -1,26 +1,111 @@
 import { FixtureSubprovider } from '@bitski/provider-engine';
-import { BitskiEngine } from '../src/bitski-engine';
+import { BitskiEngine, BitskiEngineOptions } from '../src/bitski-engine';
 
-function createEngine(): BitskiEngine {
-  const engine = new BitskiEngine();
+function createEngine(opts?: BitskiEngineOptions): BitskiEngine {
+  const engine = new BitskiEngine(opts);
   engine.addProvider(new FixtureSubprovider({
     eth_blockNumber: '0x0',
     eth_getBlockByNumber: false,
   }));
   engine.start();
-  engine._blockTracker.emit('latest', '0x1');
   return engine;
 }
 
-test('it exists', () => {
-  const engine = createEngine();
-  expect(engine).toBeDefined();
+describe('initialization', () => {
+  test('it exists', () => {
+    expect.assertions(2);
+    const engine = createEngine();
+    expect(engine).toBeDefined();
+    expect(engine._providers.length).toBe(8);
+  });
+
+  test('it respects disableCaching option', () => {
+    expect.assertions(1);
+    const engine = createEngine({ disableCaching: true });
+    expect(engine._providers.length).toBe(6);
+  });
 });
 
-test('it forwards sends when callback is present', () => {
-  const engine = createEngine();
-  const spy = jest.spyOn(engine, 'sendAsync');
-  // @ts-ignore
-  engine.send({}, jest.fn());
-  expect(spy).toBeCalled();
+describe('when handling subscriptions', () => {
+  test('it has support for subscriptions', () => {
+    const engine = createEngine();
+    expect(engine.supportsSubscriptions()).toBe(true);
+  });
+
+  test('it can subscribe to events', (done) => {
+    const engine = createEngine();
+    const spy = jest.spyOn(engine, 'send').mockResolvedValue('0x1');
+    engine.subscribe('eth_subscribe', 'logs', []).then((result) => {
+      expect(result).toBe('0x1');
+      expect(spy).toBeCalled();
+      done();
+    });
+  });
+
+  test('it can unsubscribe from events', (done) => {
+    const engine = createEngine();
+    const spy = jest.spyOn(engine, 'send').mockResolvedValue(true);
+    engine.unsubscribe('0x1').then((result) => {
+      expect(result).toBe(true);
+      expect(spy).toBeCalled();
+      done();
+    });
+  });
+
+  test('it emits events with subscription id', (done) => {
+    expect.assertions(1);
+    const engine = createEngine();
+    const subscriptionSubprovider = engine._providers[5];
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        subscription: '0x1',
+        result: {
+          foo: 'bar',
+        },
+      },
+    };
+    engine.on('0x1', (result) => {
+      expect(result).toEqual(notification.params);
+      done();
+    });
+    subscriptionSubprovider.emit('data', null, notification);
+  });
+
+  test('it re-emits data events for backwards compatibility', (done) => {
+    expect.assertions(1);
+    const engine = createEngine();
+    const subscriptionSubprovider = engine._providers[5];
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'eth_subscription',
+      params: {
+        subscription: '0x1',
+        result: {
+          foo: 'bar',
+        },
+      },
+    };
+    engine.on('data', (err, result) => {
+      expect(result).toEqual(notification);
+      done();
+    });
+    subscriptionSubprovider.emit('data', null, notification);
+  });
+
+  test('it does not emit subscription id events when receiving invalid data', (done) => {
+    expect.assertions(1);
+    const engine = createEngine();
+    const subscriptionSubprovider = engine._providers[5];
+    let called = false;
+    engine.on('0x1', () => {
+      called = true;
+    });
+    subscriptionSubprovider.emit('data', null, {});
+    setTimeout(() => {
+      expect(called).toBe(false);
+      done();
+    }, 200);
+  });
 });

--- a/packages/provider/tslint.json
+++ b/packages/provider/tslint.json
@@ -12,7 +12,8 @@
         },
         "indent": [true, "spaces", 2],
         "no-switch-case-fall-through": true,
-        "no-reference": false
+        "no-reference": false,
+        "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
The goal here is to support recent versions of web3, without breaking compatibility with older versions.

- Pulls in @bitski/provider-engine 0.4.1, which handle the new "send" method
- Remove custom "send" implementation
- Add subscribe and unsubscribe methods to match Web3's base provider
- Emits subscription events in new format(s) required by spec