### PR TITLE
Add ability to disable block polling

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
-      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.6.0.tgz",
+      "integrity": "sha512-dCYdaBwew6eCckJdN6ITkmsMptnI26hGaJTWKOeppEVaFlCv3IgCGIC4QAhmbNlGXm5u8HErq3YTf7YDrw7GSg==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -21,7 +21,7 @@
     "prepack": "npm run build && npm run bundle"
   },
   "dependencies": {
-    "@bitski/provider-engine": "^0.4.1",
+    "@bitski/provider-engine": "^0.6.0",
     "@openid/appauth": "^1.2.0",
     "bitski-provider": "^0.7.0-alpha.0",
     "uuid": "^3.3.2"

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -35,6 +35,7 @@ export interface ProviderOptions extends BitskiEngineOptions {
   pollingInterval?: number;
   disableCaching?: boolean;
   disableValidation?: boolean;
+  disableBlockTracking?: boolean;
   additionalHeaders?: object;
   webBaseUrl?: string;
   apiBaseUrl?: string;

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -99,7 +99,7 @@ describe('managing providers', () => {
     const provider = bitski.getProvider({ networkName: 'mainnet', pollingInterval: 10000000 });
     provider.on('error', (error) => {});
     // @ts-ignore
-    expect(provider._blockTracker._pollingInterval).toBe(10000000);
+    expect(provider._blockTracker._blockTracker._pollingInterval).toBe(10000000);
   });
 
   test('should pass additional headers to providers', () => {
@@ -143,10 +143,10 @@ describe('managing providers', () => {
     const provider = bitski.getProvider('kovan');
     provider.on('error', (error) => {});
     // @ts-ignore
-    expect(provider._blockTracker._isRunning).toBe(true);
+    expect(provider.isRunning()).toBe(true);
     bitski.signOut();
     // @ts-ignore
-    expect(provider._blockTracker._isRunning).toBe(false);
+    expect(provider.isRunning()).toBe(false);
   });
 
   test('should not stop engine when force logged out', () => {

--- a/packages/browser/tests/util/mock-engine.ts
+++ b/packages/browser/tests/util/mock-engine.ts
@@ -23,12 +23,4 @@ export class MockEngine extends Web3ProviderEngine {
       eth_getBalance: '0x1',
     }));
   }
-
-  public start() {
-    super.start();
-    // Emit a block after a short delay to start requests
-    setTimeout(() => {
-      this._blockTracker.emit('latest', '0x1');
-    }, 500);
-  }
 }

--- a/packages/provider/package-lock.json
+++ b/packages/provider/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
-      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.6.0.tgz",
+      "integrity": "sha512-dCYdaBwew6eCckJdN6ITkmsMptnI26hGaJTWKOeppEVaFlCv3IgCGIC4QAhmbNlGXm5u8HErq3YTf7YDrw7GSg==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -17,7 +17,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@bitski/provider-engine": "^0.4.1",
+    "@bitski/provider-engine": "^0.6.0",
     "async": "^3.0.1",
     "json-rpc-error": "^2.0.0"
   },

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -17,6 +17,8 @@ export interface BitskiEngineOptions {
   disableCaching?: boolean;
   // Disable transaction validation
   disableValidation?: boolean;
+  // Disable polling for new blocks
+  disableBlockTracking?: boolean;
 }
 
 export class BitskiEngine extends Web3ProviderEngine {
@@ -64,15 +66,17 @@ export class BitskiEngine extends Web3ProviderEngine {
   }
 
   public supportsSubscriptions(): boolean {
-    return true;
+    return this._pollForBlocks;
   }
 
   public subscribe(subscribeMethod: string = 'eth_subscribe', subscriptionMethod: string, parameters: any[]): Promise<string> {
+    if (!this._pollForBlocks) { return Promise.reject(new Error('Subscriptions are not supported')); }
     parameters.unshift(subscriptionMethod);
     return this.send(subscribeMethod, parameters);
   }
 
   public unsubscribe(subscriptionId: string, unsubscribeMethod: string = 'eth_unsubscribe'): Promise<boolean> {
+    if (!this._pollForBlocks) { return Promise.reject(new Error('Subscriptions are not supported')); }
     return this.send(unsubscribeMethod, [subscriptionId]).then((response) => {
       if (response) {
           this.removeAllListeners(subscriptionId);

--- a/packages/provider/tests/authenticated-fetch.test.ts
+++ b/packages/provider/tests/authenticated-fetch.test.ts
@@ -25,7 +25,7 @@ function createFetchProvider(): AuthenticatedFetchSubprovider {
 }
 
 function createEngine(fetchProvider: AuthenticatedFetchSubprovider): MockEngine {
-  const engine = new MockEngine();
+  const engine = new MockEngine({ disableBlockTracking: true, disableCaching: true });
   engine.addProvider(fetchProvider);
   engine.start();
   return engine;

--- a/packages/provider/tests/util/mock-engine.ts
+++ b/packages/provider/tests/util/mock-engine.ts
@@ -2,8 +2,8 @@ import Web3ProviderEngine from '@bitski/provider-engine';
 import { FixtureSubprovider } from '@bitski/provider-engine';
 
 export class MockEngine extends Web3ProviderEngine {
-  constructor() {
-    super();
+  constructor(opts) {
+    super(opts);
     this.addProvider(new FixtureSubprovider({
       eth_blockNumber: '0x0',
       eth_getBlockByNumber: false,
@@ -13,13 +13,5 @@ export class MockEngine extends Web3ProviderEngine {
       net_listening: true,
       web3_clientVersion: 'ProviderEngine/v0.0.0/javascript',
     }));
-  }
-
-  public start() {
-    super.start();
-    // Emit a block after a short delay to start requests
-    setTimeout(() => {
-      this._blockTracker.emit('latest', '0x1');
-    }, 500);
   }
 }


### PR DESCRIPTION
- Pull in changes from 0.6.0 of provider-engine
- Disable support for subscriptions when polling is disabled