### PR TITLE
Disable refresh token recovery error recovery via popup

### DIFF
--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -108,10 +108,7 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
         case AuthenticationStatus.Connected:
             return this.loadUser();
         case AuthenticationStatus.Expired:
-            return this.connect().catch((err) => {
-                // If refreshing fails, attempt to sign in
-                return this.signIn(signInMethod);
-            });
+            return this.connect();
         case AuthenticationStatus.NotConnected:
             return this.signIn(signInMethod);
         }

--- a/packages/browser/tests/auth-provider.test.ts
+++ b/packages/browser/tests/auth-provider.test.ts
@@ -288,26 +288,6 @@ describe('sign in or connect', () => {
     });
   });
 
-  test('should sign in popup when refreshing access token fails', () => {
-    expect.assertions(4);
-    const authProvider = createInstance();
-    (authProvider.tokenStore as MockTokenStore).setRefreshToken('test-refresh-token');
-    const connectMock = jest.spyOn(authProvider, 'connect').mockRejectedValue(new Error('Async error'));
-    const tokenResponse = new TokenResponse({
-      access_token: 'test-access-token',
-    });
-    const signinMock = jest.spyOn(authProvider.oauthManager, 'signInPopup').mockResolvedValue(tokenResponse);
-    const getUserMock = jest.spyOn(authProvider.oauthManager, 'requestUserInfo').mockResolvedValue({
-      sub: 'test-user',
-    });
-    return authProvider.signInOrConnect().then((user) => {
-      expect(user).toMatchObject(dummyUser);
-      expect(connectMock).toHaveBeenCalled();
-      expect(signinMock).toHaveBeenCalled();
-      expect(getUserMock).toHaveBeenCalled();
-    });
-  });
-
   test('should sign in popup if not connected', () => {
     expect.assertions(3);
     const authProvider = createInstance();


### PR DESCRIPTION
Turns out, this never works. The popup is always blocked because it's called within an asynchronous function.