### PR TITLE
Add explicit api for retrieving access token / refresh token

### DIFF
--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -49,6 +49,18 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
         return Promise.reject(new Error('Not signed in. Please sign in and try your request again.'));
     }
 
+    public getRefreshToken(): Promise<string> {
+        if (this.tokenStore.refreshToken) {
+            return Promise.resolve(this.tokenStore.refreshToken);
+        }
+        // Error: the user did not approve this app for offline access
+        if (this.tokenStore.currentToken) {
+            return Promise.reject(new Error('Refresh token is not available.'));
+        }
+        // Error: the user is not signed in.
+        return Promise.reject(new Error('Not signed in. Please sign in and try your request again.'));
+    }
+
     public invalidateToken(): Promise<void> {
         if (this.tokenStore.currentToken) {
             this.tokenStore.invalidateCurrentToken();

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -185,6 +185,21 @@ export class Bitski {
   }
 
   /**
+   * Retrieves the current access token for the user, if logged in.
+   */
+  public getCurrentAccessToken(): Promise<string> {
+    return this.authProvider.getAccessToken();
+  }
+
+  /**
+   * Retrieves the current refresh token for the user, if logged in.
+   * Requires that the user has approved your application for offline access.
+   */
+  public getCurrentRefreshToken(): Promise<string> {
+    return this.authProvider.getRefreshToken();
+  }
+
+  /**
    * Register a callback to be called on sign out. This is a good practice,
    * since there may be situations where you are signed out unexpectedly.
    * @param fn Your callback function

--- a/packages/browser/tests/auth-provider.test.ts
+++ b/packages/browser/tests/auth-provider.test.ts
@@ -116,6 +116,31 @@ describe('getting an access token', () => {
       expect(token).toBe(dummyToken.token);
     });
   });
+
+  test('should be able to get a refresh token if the user is logged in', () => {
+    const authProvider = createInstance();
+    (authProvider.tokenStore as MockTokenStore).setRefreshToken('test-refresh-token');
+    return authProvider.getRefreshToken().then((token) => {
+      expect(token).toBe('test-refresh-token');
+    });
+  });
+
+  test('should not be able to get a refresh token if the user is not logged in', (done) => {
+    const authProvider = createInstance();
+    authProvider.getRefreshToken().catch((error) => {
+      expect(error.message).toMatch(/Not signed in/);
+      done();
+    });
+  });
+
+  test('should not be able to get a refresh token if the user did not approve offline access', (done) => {
+    const authProvider = createInstance();
+    (authProvider.tokenStore as MockTokenStore).setToken(dummyToken);
+    authProvider.getRefreshToken().catch((error) => {
+      expect(error.message).toMatch(/Refresh token is not available/);
+      done();
+    });
+  });
 });
 
 describe('refreshing access tokens', () => {

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -288,7 +288,24 @@ describe('authentication', () => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
   });
+});
 
+describe('working with access tokens', () => {
+  test('should be able to get an access token if the user is logged in', () => {
+    const bitski = createInstance();
+    jest.spyOn(bitski.authProvider, 'getAccessToken').mockResolvedValue('test-access-token');
+    return bitski.getCurrentAccessToken().then((accessToken) => {
+      expect(accessToken).toBe('test-access-token');
+    });
+  });
+
+  test('should be able to get a refresh token if the user is logged in', () => {
+    const bitski = createInstance();
+    jest.spyOn(bitski.authProvider, 'getRefreshToken').mockResolvedValue('test-refresh-token');
+    return bitski.getCurrentRefreshToken().then((refreshToken) => {
+      expect(refreshToken).toBe('test-refresh-token');
+    });
+  });
 });
 
 describe('connect button', () => {


### PR DESCRIPTION
Adds two new top level methods for retrieving the user's access token

- `getCurrentAccessToken(): Promise<string>`
- `getCurrentRefreshToken(): Promise<string>`

Getting an access token will attempt to refresh if the token is expired, and will reject the promise if a token cannot be found or refreshed.

Getting a refresh token will simply access the data store, but you will receive a nuanced error based on whether the user is logged in, or hasn't allowed offline access.

The primary use case for this API is handoff between client and server for verification purposes. Technically this data has been available through accessing private apis, but that can be brittle.