### PR TITLE
Add ability to pass login_hint during signIn()

### DIFF
--- a/packages/browser/src/auth/auth-provider.ts
+++ b/packages/browser/src/auth/auth-provider.ts
@@ -1,11 +1,12 @@
 import { AuthenticationStatus, OAuthSignInMethod } from '../bitski';
+import { SignInOptions } from './oauth-manager';
 import { User } from './user';
 
 export interface AuthProvider {
     readonly authStatus: AuthenticationStatus;
-    signIn(method: OAuthSignInMethod): Promise<User>;
+    signIn(method: OAuthSignInMethod, opts?: SignInOptions): Promise<User>;
     connect(): Promise<User>;
-    signInOrConnect(signInMethod?: OAuthSignInMethod): Promise<User>;
+    signInOrConnect(signInMethod?: OAuthSignInMethod, opts?: SignInOptions): Promise<User>;
     getUser(): Promise<User>;
     redirectCallback(): Promise<User>;
     signOut(): Promise<User>;

--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -1,7 +1,7 @@
 import { AccessTokenProvider } from 'bitski-provider';
 import { AuthenticationStatus, BitskiSDKOptions, OAuthSignInMethod } from '../bitski';
 import { AuthProvider } from './auth-provider';
-import { OAuthManager, OAuthManagerOptions } from './oauth-manager';
+import { OAuthManager, OAuthManagerOptions, SignInOptions } from './oauth-manager';
 import { TokenStore } from './token-store';
 import { User } from './user';
 import { UserStore } from './user-store';
@@ -86,16 +86,16 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
         return Promise.reject(new Error('No refresh token available'));
     }
 
-    public signIn(method: OAuthSignInMethod): Promise<User> {
+    public signIn(method: OAuthSignInMethod, opts?: SignInOptions): Promise<User> {
         let promise: Promise<any>;
         switch (method) {
             case OAuthSignInMethod.Redirect:
-                promise = this.oauthManager.signInRedirect();
+                promise = this.oauthManager.signInRedirect(opts);
                 break;
             case OAuthSignInMethod.Silent:
                 return Promise.reject(new Error('Silent is no longer supported'));
             default:
-                promise = this.oauthManager.signInPopup();
+                promise = this.oauthManager.signInPopup(opts);
                 break;
         }
 
@@ -115,14 +115,14 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
         return this.getOrFetchUser();
     }
 
-    public signInOrConnect(signInMethod: OAuthSignInMethod = OAuthSignInMethod.Popup): Promise<User> {
+    public signInOrConnect(signInMethod: OAuthSignInMethod = OAuthSignInMethod.Popup, opts?: SignInOptions): Promise<User> {
         switch (this.authStatus) {
         case AuthenticationStatus.Connected:
             return this.loadUser();
         case AuthenticationStatus.Expired:
             return this.connect();
         case AuthenticationStatus.NotConnected:
-            return this.signIn(signInMethod);
+            return this.signIn(signInMethod, opts);
         }
     }
 

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -1,5 +1,6 @@
 import { AuthorizationServiceConfiguration } from '@openid/appauth';
 import { BitskiEngine, BitskiEngineOptions, Kovan, Mainnet, Network, Rinkeby } from 'bitski-provider';
+import { LOGIN_HINT_SIGNUP, SignInOptions } from './auth/oauth-manager';
 import { OpenidAuthProvider } from './auth/openid-auth-provider';
 import { User } from './auth/user';
 import { ConnectButton, ConnectButtonSize } from './components/connect-button';
@@ -19,6 +20,9 @@ export enum AuthenticationStatus {
   Expired = 'EXPIRED',
   NotConnected = 'NOT_CONNECTED',
 }
+
+// Sign-in Options
+export { SignInOptions, LOGIN_HINT_SIGNUP };
 
 // Networks
 export { Network, Mainnet, Rinkeby, Kovan };
@@ -129,9 +133,10 @@ export class Bitski {
    * Signs in or connects to bitski depending on the user's auth state.
    * Since it may open a popup, this method must be called from user interaction handler,
    * such as a click or tap handler.
+   * @param options Provide SignInOptions for the sign in request. See signIn() for more info.
    */
-  public start(): Promise<User> {
-    return this.authProvider.signInOrConnect();
+  public start(options?: SignInOptions): Promise<User> {
+    return this.authProvider.signInOrConnect(undefined, options);
   }
 
   /**
@@ -142,18 +147,18 @@ export class Bitski {
   }
 
   /**
-   * DEPRECATED - use bitski.authStatus instead.
-   * Check the logged in state of the user. Either connected (have an active session), expired (connected but needs new access token), or not connected.
-   */
-  public getAuthStatus(): Promise<AuthenticationStatus> {
-    return Promise.resolve(this.authProvider.authStatus);
-  }
-
-  /**
    * Starts the sign in flow. Will trigger a popup window over your app, so it must be called within a user interaction handler such as a click.
+   * @param options Optionally provide additional options for the sign in request.
+   *
+   * You can use the options parameter to request that we show the sign up form instead of the sign in form:
+   * ```javascript
+   * import { LOGIN_HINT_SIGNUP } from 'bitski';
+   *
+   * await bitski.signIn({ login_hint: LOGIN_HINT_SIGNUP });
+   * ```
    */
-  public signIn(): Promise<User> {
-    return this.authProvider.signIn(OAuthSignInMethod.Popup);
+  public signIn(options?: SignInOptions): Promise<User> {
+    return this.authProvider.signIn(OAuthSignInMethod.Popup, options);
   }
 
   /**
@@ -172,9 +177,10 @@ export class Bitski {
 
   /**
    * Starts redirect sign in flow. This is an alternative flow to the popup that all takes place in the same browser window.
+   * @param options Optionally provide additional options for the sign in request. See signIn() for more info.
    */
-  public signInRedirect(): void {
-    this.authProvider.signIn(OAuthSignInMethod.Redirect);
+  public signInRedirect(options?: SignInOptions): void {
+    this.authProvider.signIn(OAuthSignInMethod.Redirect, options);
   }
 
   /**

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -13,6 +13,7 @@ describe('managing providers', () => {
 
   beforeEach(() => {
     // This doesn't seem to be working. Instead catching network errors and silencing them.
+    // @ts-ignore
     fetch.mockResponse(JSON.stringify({ jsonrpc: '2.0', id: 0, result: null }));
   });
 
@@ -188,10 +189,9 @@ describe('authentication', () => {
     // @ts-ignore
     const spy = jest.spyOn(bitski.authProvider, 'authStatus', 'get');
     spy.mockReturnValue(AuthenticationStatus.Connected);
-    return bitski.getAuthStatus().then((authStatus) => {
-      expect(authStatus).toBe(AuthenticationStatus.Connected);
-      expect(authStatus).toBe(bitski.authStatus);
-    });
+    const authStatus = bitski.authStatus;
+    expect(authStatus).toBe(AuthenticationStatus.Connected);
+    expect(authStatus).toBe(bitski.authStatus);
   });
 
   test('should log in via popup', () => {
@@ -201,7 +201,20 @@ describe('authentication', () => {
     const spy = jest.spyOn(bitski.authProvider, 'signIn');
     spy.mockResolvedValue(dummyUser);
     return bitski.signIn().then((user) => {
-      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Popup);
+      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Popup, undefined);
+      expect(user).toBe(dummyUser);
+    });
+  });
+
+  test('should pass options when signing in', () => {
+    expect.assertions(2);
+    const bitski = createInstance();
+    // @ts-ignore
+    const spy = jest.spyOn(bitski.authProvider, 'signIn');
+    spy.mockResolvedValue(dummyUser);
+    const opts = { login_hint: 'foo' };
+    return bitski.signIn(opts).then((user) => {
+      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Popup, opts);
       expect(user).toBe(dummyUser);
     });
   });
@@ -214,7 +227,21 @@ describe('authentication', () => {
     spy.mockResolvedValue(dummyUser);
     bitski.signInRedirect();
     setTimeout(() => {
-      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Redirect);
+      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Redirect, undefined);
+      done();
+    }, 500);
+  });
+
+  test('should pass options when signing in via redirect', (done) => {
+    expect.assertions(1);
+    const bitski = createInstance();
+    // @ts-ignore
+    const spy = jest.spyOn(bitski.authProvider, 'signIn');
+    spy.mockResolvedValue(dummyUser);
+    const opts = { login_hint: 'foo' };
+    bitski.signInRedirect(opts);
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalledWith(OAuthSignInMethod.Redirect, opts);
       done();
     }, 500);
   });

--- a/packages/browser/tests/oauth-manager.test.ts
+++ b/packages/browser/tests/oauth-manager.test.ts
@@ -1,8 +1,9 @@
-import { OAuthManager } from '../src/auth/oauth-manager';
 import { NoHashQueryStringUtils } from '../src/utils/no-hash-query-string-utils';
+import { MockOAuthManager } from './util/mock-oauth-manager';
+import { LOGIN_HINT_SIGNUP } from '../src/bitski';
 
 function createInstance() {
-  return new OAuthManager({ clientId: 'test-client-id', redirectUri: 'http://localhost:3000' });
+  return new MockOAuthManager({ clientId: 'test-client-id', redirectUri: 'http://localhost:3000' });
 }
 
 beforeEach(() => {
@@ -52,7 +53,7 @@ test('sign in popup opens popup', () => {
   const manager = createInstance();
 
   // Spy on window open
-  jest.spyOn(window, 'open').mockImplementation((url, target, features) => {
+  jest.spyOn(window, 'open').mockImplementationOnce((url, target, features) => {
     // Assert the URL is something we expect
     expect(url).toMatch(manager.configuration.authorizationEndpoint);
     // Hack to create an object that is similar to Location in JSDom
@@ -69,6 +70,22 @@ test('sign in popup opens popup', () => {
   return manager.signInPopup().then((tokenResponse) => {
     expect(tokenResponse.accessToken).toBe('test-token');
   });
+});
+
+test('signInPopup passes options to authorization request', () => {
+  expect.assertions(2);
+  const manager = createInstance();
+  manager.signInPopup({ login_hint: LOGIN_HINT_SIGNUP });
+  expect(manager.currentAuthRequest).toBeDefined();
+  expect(manager.currentAuthRequest.extras.login_hint).toBe(LOGIN_HINT_SIGNUP);
+});
+
+test('signInRedirect passes options to authorization request', () => {
+  expect.assertions(2);
+  const manager = createInstance();
+  manager.signInRedirect({ login_hint: LOGIN_HINT_SIGNUP });
+  expect(manager.currentAuthRequest).toBeDefined();
+  expect(manager.currentAuthRequest.extras.login_hint).toBe(LOGIN_HINT_SIGNUP);
 });
 
 test('can handle oauth error response', () => {

--- a/packages/browser/tests/util/mock-oauth-manager.ts
+++ b/packages/browser/tests/util/mock-oauth-manager.ts
@@ -1,0 +1,26 @@
+import { AuthorizationRequest, TokenRequest } from '@openid/appauth';
+import { OAuthManager, SignInOptions } from '../../src/auth/oauth-manager';
+
+export class MockOAuthManager extends OAuthManager {
+  public currentAuthRequest?: AuthorizationRequest;
+  public currentTokenRequest?: TokenRequest;
+
+  protected createAuthRequest(opts: SignInOptions): AuthorizationRequest {
+    const request = super.createAuthRequest(opts);
+    this.currentAuthRequest = request;
+    return request;
+  }
+
+  protected createTokenRequest(code: string): TokenRequest {
+    const request = super.createTokenRequest(code);
+    this.currentTokenRequest = request;
+    return request;
+  }
+
+  protected createRefreshTokenRequest(refreshToken: string): TokenRequest {
+    const request = super.createRefreshTokenRequest(refreshToken);
+    this.currentTokenRequest = request;
+    return request;
+  }
+
+}


### PR DESCRIPTION
Enable the use of OpenID's login_hint, and allow it to be used to default to sign up instead of log in.