### PR TITLE
Add support for eth_signTypedData

### DIFF
--- a/examples/callback/callback.html
+++ b/examples/callback/callback.html
@@ -5,6 +5,6 @@
     <title>Logging in...</title>
   </head>
   <body>
-    <script src="/node_modules/bitski/lib/utils/callback.js"></script>
+    <script src="/node_modules/bitski/dist/callback.js"></script>
   </body>
 </html>

--- a/examples/common.js
+++ b/examples/common.js
@@ -3,10 +3,8 @@ import Web3 from 'web3';
 
 console.log("Setting up bitski...");
 
-var bitski = new Bitski('3b6d0360-071c-4210-8862-176164d6ec76', 'http://localhost:8080/callback/callback.html');
-var provider = bitski.getProvider();
-
-window.bitski = bitski;
-window.web3 = new Web3(provider);
+window.bitski = new Bitski('3b6d0360-071c-4210-8862-176164d6ec76', 'http://localhost:8080/callback/callback.html');
+window.provider = window.bitski.getProvider();
+window.web3 = new Web3(window.provider);
 
 window.web3.eth.getBlockNumber().then(number => console.log(number));

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,5 +4,6 @@
   </head>
   <body>
     <a href="/connect-button">Connect Button Example</a>
+    <a href="/sign-typed-data">Sign Typed Data</a>
   </body>
 </html>

--- a/examples/sign-typed-data/index.html
+++ b/examples/sign-typed-data/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <script src="/common.js"></script>
+    <script src="index.js"></script>
+
+    <h1>Sign Typed Data</h1>
+
+    <div id="logged-in" style="display: none;">
+      <a id="sign-button" href="#">Sign Typed Data Payload</a>
+    </div>
+    <div id="logged-out" style="display: none;">
+      <div id="connect-button"></div>
+    </div>
+
+  </body>
+</html>

--- a/examples/sign-typed-data/index.js
+++ b/examples/sign-typed-data/index.js
@@ -1,0 +1,91 @@
+window.addEventListener("load", function() {
+  const bitski = window.bitski;
+
+  // Create connect button
+  const connectButton = bitski.getConnectButton({ container: document.querySelector('#connect-button') });
+  connectButton.callback = function(error, user){
+    if (user) {
+      updateLoggedInState();
+    }
+
+    if (error) {
+      console.error("Error signing in: " + error);
+    }
+  };
+
+  const signButton = document.querySelector("#sign-button");
+  signButton.onclick = () => {
+    signTypedData();
+    return false;
+  };
+
+  updateLoggedInState();
+});
+
+function updateLoggedInState() {
+  const loggedOutContainer = document.querySelector('#logged-out');
+  const loggedInContainer = document.querySelector('#logged-in');
+
+  if (bitski.authStatus === 'NOT_CONNECTED') {
+    loggedOutContainer.style = 'display: block;';
+    loggedInContainer.style = 'display: none;';
+  } else {
+    loggedOutContainer.style = 'display: none;';
+    loggedInContainer.style = 'display: block;';
+  }
+}
+
+function signTypedData() {
+  const web3 = window.web3;
+  const provider = window.provider;
+  const msgParams = {
+    types: {
+        EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+        ],
+        Person: [
+            { name: 'name', type: 'string' },
+            { name: 'wallet', type: 'address' }
+        ],
+        Mail: [
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' }
+        ],
+    },
+    primaryType: 'Mail',
+    domain: {
+        name: 'Ether Mail',
+        version: '0x1',
+        chainId: '0x1',
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    },
+    message: {
+        from: {
+            name: 'Cow',
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: {
+            name: 'Bob',
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        },
+        contents: 'Hello, Bob!',
+    },
+  };
+  console.log("Sending: ", JSON.stringify(msgParams));
+  web3.eth.getAccounts().then(accounts => {
+    const from = accounts[0];
+    provider.send('eth_signTypedData', [from, msgParams]).then(response => {
+      console.log("Success! Response: " + response);
+      alert(`Signed data: ${response}`);
+    }).catch(err => {
+      console.error('Error signing: ' + err);
+    });
+  }).catch(err => {
+    console.error('Error getting accounts: '+ err);
+  });
+
+}

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -29,4 +29,11 @@ export const USER_KEY = 'bitski.user';
 
 // Methods
 export const CACHED_METHODS = ['eth_accounts'];
-export const DEFAULT_AUTHORIZED_METHODS = ['eth_sendTransaction', 'eth_signTransaction', 'eth_sign', 'personal_sign'];
+export const DEFAULT_AUTHORIZED_METHODS = [
+  'eth_sendTransaction',
+  'eth_signTransaction',
+  'eth_sign',
+  'personal_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v3', // For metamask compatibility
+];

--- a/packages/browser/src/errors/signer-error.ts
+++ b/packages/browser/src/errors/signer-error.ts
@@ -10,6 +10,11 @@ export enum SignerErrorCode {
   // The message signature request is missing expected params.
   // Check that params is an array, and that they include both a from address, and a message to sign.
   MissingMessage = 3003,
+  // Missing from address in typed data request
+  MissingFrom = 3004,
+  // Missing typed data params. Make sure params is an array and includes
+  // both a from address, and a typed data payload.
+  MissingTypedData = 3005,
 }
 
 export class SignerError extends Error {
@@ -28,6 +33,14 @@ export class SignerError extends Error {
 
   public static MissingMessage() {
     return new SignerError('Could not find message params in request', SignerErrorCode.MissingMessage);
+  }
+
+  public static MissingFrom() {
+    return new SignerError('Could not find from address in request params.', SignerErrorCode.MissingFrom);
+  }
+
+  public static MissingTypedData() {
+    return new SignerError('Could not find data to sign in request params.', SignerErrorCode.MissingTypedData);
   }
 
   public name: string = 'TransactionError';

--- a/packages/browser/src/subproviders/signature.ts
+++ b/packages/browser/src/subproviders/signature.ts
@@ -12,6 +12,7 @@ export enum TransactionKind {
   SendTransaction = 'ETH_SEND_TRANSACTION',
   SignTransaction = 'ETH_SIGN_TRANSACTION',
   Sign = 'ETH_SIGN',
+  SignTypedData = 'ETH_SIGN_TYPED_DATA',
 }
 
 export interface Transaction {
@@ -22,8 +23,9 @@ export interface Transaction {
 }
 
 export interface TransactionContext {
-  chainId: number;
+  chainId?: number;
   currentBalance?: string;
+  from?: string;
 }
 
 export interface SignaturePayload {
@@ -39,6 +41,63 @@ export interface TransactionPayload {
   nonce?: string;
   gas?: string;
   gasPrice?: string;
+}
+
+export interface TypedDataDefinition {
+  name: string; // name of the property
+  type: string; // 'string', 'uint', 'address', or 'CustomType' for nested structs
+}
+/**
+ * Example usage:
+ * ```javascript
+ * const payload: TypedDataPayload = {
+ *   types: {
+ *     EIP712Domain: [
+ *       { name: 'name', type: 'string' },
+ *       { name: 'version', type: 'string' },
+ *       { name: 'chainId', type: 'uint256' },
+ *       { name: 'verifyingContract', type: 'address' },
+ *     ],
+ *     Person: [
+ *       { name: 'name', type: 'string' },
+ *       { name: 'wallet', type: 'address' }
+ *     ],
+ *     Mail: [
+ *       { name: 'from', type: 'Person' },
+ *       { name: 'to', type: 'Person' },
+ *       { name: 'contents', type: 'string' }
+ *     ],
+ *   },
+ *   primaryType: 'Mail',
+ *   domain: {
+ *     name: 'Ether Mail',
+ *     version: '1',
+ *     chainId: 1,
+ *     verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+ *   },
+ *   message: {
+ *     from: {
+ *       name: 'Cow',
+ *       wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+ *     },
+ *     to: {
+ *       name: 'Bob',
+ *       wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+ *     },
+ *     contents: 'Hello, Bob!',
+ *   },
+ * }
+ * ```
+ */
+
+export interface TypedDataPayload {
+  types: {
+    EIP712Domain: TypedDataDefinition[]; // Required. Specify the domain fields you are using.
+    [propName: string]: TypedDataDefinition[]; // Include your custom types here.
+  };
+  domain: object; // Provide object format of domain according to spec in `types`
+  primaryType: string; // The name of the top-level type being used in `message`
+  message: object; // The values for your object, starting from the `primaryType`
 }
 
 /**
@@ -158,8 +217,7 @@ export class SignatureSubprovider extends Subprovider {
    * @param payload JSON-RPC payload to extract the values from
    */
   protected async createBitskiTransaction(payload: JSONRPCRequestPayload): Promise<Transaction> {
-    const context = { chainId: this.network.chainId } as TransactionContext;
-    context.currentBalance = await this.loadBalanceIfNeeded(payload);
+    const context = await this.createContext(payload);
     const kind = this.kindForMethod(payload.method);
     const extractedPayload = this.createPayload(payload);
     const transaction = {
@@ -171,11 +229,30 @@ export class SignatureSubprovider extends Subprovider {
     return transaction as Transaction;
   }
 
+  private async createContext(request: JSONRPCRequestPayload): Promise<TransactionContext> {
+    switch (request.method) {
+      case 'eth_sendTransaction':
+      case 'eth_signTransaction':
+        const balance = await this.loadBalanceIfNeeded(request);
+        return { chainId: this.network.chainId, currentBalance: balance };
+      case 'eth_signTypedData':
+      case 'eth_signTypedData_v3':
+        // The from address should be the first parameter as a 20 byte hex string
+        if (request.params && request.params.length > 0) {
+          return { from: request.params[0] };
+        }
+        throw new Error('Invalid request: No from address specified');
+      default:
+        // Other transaction types do not need context
+        return {};
+    }
+  }
+
   /**
    * Responsible for creating the payload from a given RPC request
    * @param request JSON-RPC request to extract params from
    */
-  private createPayload(request: JSONRPCRequestPayload): TransactionPayload | SignaturePayload {
+  private createPayload(request: JSONRPCRequestPayload): TransactionPayload | SignaturePayload | TypedDataPayload {
     switch (request.method) {
       case 'eth_sendTransaction':
       case 'eth_signTransaction':
@@ -196,6 +273,13 @@ export class SignatureSubprovider extends Subprovider {
         } else {
           throw SignerError.MissingMessage();
         }
+      case 'eth_signTypedData':
+      case 'eth_signTypedData_v3':
+        if (request.params && request.params.length > 1) {
+          return request.params[1] as TypedDataPayload;
+        } else {
+          throw new Error('Invalid request: Could not find typed data to sign.');
+        }
       default:
         throw SignerError.UnsupportedMethod();
     }
@@ -215,6 +299,9 @@ export class SignatureSubprovider extends Subprovider {
       case 'eth_sign':
       case 'personal_sign':
         return TransactionKind.Sign;
+      case 'eth_signTypedData':
+      case 'eth_signTypedData_v3':
+        return TransactionKind.SignTypedData;
       default:
         throw SignerError.UnsupportedMethod();
     }

--- a/packages/browser/src/subproviders/signature.ts
+++ b/packages/browser/src/subproviders/signature.ts
@@ -241,7 +241,7 @@ export class SignatureSubprovider extends Subprovider {
         if (request.params && request.params.length > 0) {
           return { from: request.params[0] };
         }
-        throw new Error('Invalid request: No from address specified');
+        throw SignerError.MissingFrom();
       default:
         // Other transaction types do not need context
         return {};
@@ -278,7 +278,7 @@ export class SignatureSubprovider extends Subprovider {
         if (request.params && request.params.length > 1) {
           return request.params[1] as TypedDataPayload;
         } else {
-          throw new Error('Invalid request: Could not find typed data to sign.');
+          throw SignerError.MissingTypedData();
         }
       default:
         throw SignerError.UnsupportedMethod();

--- a/packages/browser/tests/signature-subprovider.test.ts
+++ b/packages/browser/tests/signature-subprovider.test.ts
@@ -76,7 +76,7 @@ test('should handle errors when forwarding a signed transaction fails', (done) =
     // @ts-ignore
     const signSpy = jest.spyOn(instance.signer, 'sign');
     const sendSpy = jest.spyOn(instance, 'emitPayload');
-    sendSpy.mockImplementation((request, callback) => {
+    sendSpy.mockImplementation((_, callback) => {
         callback(new Error('Service Unavailable'));
     });
 
@@ -118,6 +118,62 @@ test('should sign transaction when eth_signTransaction is called', (done) => {
       done();
   });
 });
+
+test('should sign typed data', () => {
+    expect.assertions(6);
+    const { provider, instance } = createProvider();
+
+    const typedData = {
+        types: {
+            EIP712Domain: [
+                { name: 'name', type: 'string' },
+                { name: 'version', type: 'string' },
+                { name: 'chainId', type: 'uint256' },
+                { name: 'verifyingContract', type: 'address' },
+            ],
+            Person: [
+                { name: 'name', type: 'string' },
+                { name: 'wallet', type: 'address' },
+            ],
+            Mail: [
+                { name: 'from', type: 'Person' },
+                { name: 'to', type: 'Person' },
+                { name: 'contents', type: 'string' },
+            ],
+        },
+        primaryType: 'Mail',
+        domain: {
+            name: 'Ether Mail',
+            version: '1',
+            chainId: 1,
+            verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+        },
+        message: {
+            from: {
+                name: 'Cow',
+                wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            },
+            to: {
+                name: 'Bob',
+                wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+            },
+            contents: 'Hello, Bob!',
+        },
+    };
+
+    // @ts-ignore
+    const signSpy = jest.spyOn(instance.signer, 'sign');
+
+    return provider.send('eth_signTypedData', ['0xbbbb', typedData]).then((signedData) => {
+        expect(signedData).toBe('0xf00b4r');
+        expect(signSpy).toBeCalled();
+        const transaction = signSpy.mock.calls[0][0];
+        expect(transaction).not.toBeUndefined();
+        expect(transaction.payload).toMatchObject(typedData);
+        expect(transaction.kind).toBe(TransactionKind.SignTypedData);
+        expect(transaction.context.from).toBe('0xbbbb');
+    });
+  });
 
 test('should sign messages', (done) => {
   expect.assertions(8);
@@ -224,7 +280,23 @@ test('it validates parameters for requests when creating transaction', () => {
         expect(error.code).toBe(SignerErrorCode.MissingMessage);
     }
 
-    const invalidMethod = createRequest('eth_signTypedData', []);
+    const noParamsTypedData = createRequest('eth_signTypedData_v3');
+    try {
+        // @ts-ignore
+        instance.createPayload(noParamsTypedData);
+    } catch (error) {
+        expect(error).toBeInstanceOf(SignerError);
+    }
+
+    const missingParamsTypedData = createRequest('eth_signTypedData', []);
+    try {
+        // @ts-ignore
+        instance.createPayload(missingParamsTypedData);
+    } catch (error) {
+        expect(error).toBeInstanceOf(SignerError);
+    }
+
+    const invalidMethod = createRequest('eth_signTypedData_v1', []);
     try {
         // @ts-ignore
         instance.createPayload(invalidMethod);
@@ -262,7 +334,7 @@ test('it loads balance when using a custom RPC endpoint', (done) => {
     };
 
     const request = createRequest('eth_sendTransaction', [txn]);
-
+    // @ts-ignore
     const signSpy = jest.spyOn(instance.signer, 'sign');
     const emitPayloadSpy = jest.spyOn(instance, 'emitPayload');
 

--- a/packages/browser/tests/signature-subprovider.test.ts
+++ b/packages/browser/tests/signature-subprovider.test.ts
@@ -222,7 +222,7 @@ test('should sign messages with personal_sign', (done) => {
 });
 
 test('it validates parameters for requests when creating transaction', () => {
-    expect.assertions(14);
+    expect.assertions(18);
 
     const { instance } = createProvider();
 
@@ -286,6 +286,7 @@ test('it validates parameters for requests when creating transaction', () => {
         instance.createPayload(noParamsTypedData);
     } catch (error) {
         expect(error).toBeInstanceOf(SignerError);
+        expect(error.code).toBe(SignerErrorCode.MissingTypedData);
     }
 
     const missingParamsTypedData = createRequest('eth_signTypedData', []);
@@ -294,6 +295,7 @@ test('it validates parameters for requests when creating transaction', () => {
         instance.createPayload(missingParamsTypedData);
     } catch (error) {
         expect(error).toBeInstanceOf(SignerError);
+        expect(error.code).toBe(SignerErrorCode.MissingTypedData);
     }
 
     const invalidMethod = createRequest('eth_signTypedData_v1', []);

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@bitski/provider-engine": "^0.6.1",
     "async": "3.0.1",
+    "bn.js": "^4.11.8",
     "json-rpc-error": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -10,6 +10,7 @@ import {
 import { ProviderError } from './errors/provider-error';
 import { NonceTrackerSubprovider } from './subproviders/nonce-tracker';
 import { TransactionValidatorSubprovider } from './subproviders/transaction-validator';
+import { TypedDataSanitizerSubprovider } from './subproviders/typed-data';
 
 export interface BitskiEngineOptions {
   // Frequency to check for new blocks
@@ -42,6 +43,7 @@ export class BitskiEngine extends Web3ProviderEngine {
     if (enableValidator) {
       // Ensures that transactions are well formed (nonce, gas, gasPrice, from) before they are sent to Bitski
       this.addProvider(new TransactionValidatorSubprovider());
+      this.addProvider(new TypedDataSanitizerSubprovider());
     }
 
     const enableCache = !(options && options.disableCaching === true);

--- a/packages/provider/src/errors/provider-error.ts
+++ b/packages/provider/src/errors/provider-error.ts
@@ -1,6 +1,8 @@
 export enum ProviderErrorCode {
   // Thrown when accessing subscription features when they are disabled.
   SubscriptionsUnavailable = 4000,
+  // Thrown when request is missing required params or data
+  InvalidRequest = 4001,
 }
 
 export class ProviderError extends Error {
@@ -8,6 +10,11 @@ export class ProviderError extends Error {
   public static SubscriptionsUnavailable() {
     return new ProviderError('Subscriptions are disabled. Enable block polling to use this feature.', ProviderErrorCode.SubscriptionsUnavailable);
   }
+
+  public static InvalidRequest(reason: string) {
+    return new ProviderError(`Invalid request: ${reason}`, ProviderErrorCode.InvalidRequest);
+  }
+
   public name: string = 'ProviderError';
   public code: ProviderErrorCode;
 

--- a/packages/provider/src/subproviders/typed-data.ts
+++ b/packages/provider/src/subproviders/typed-data.ts
@@ -1,0 +1,190 @@
+import { Subprovider } from '@bitski/provider-engine';
+import { ProviderError } from '../errors/provider-error';
+import { JSONRPCRequestPayload } from '../index';
+import { encodeNumber } from '../utils/parse-utils';
+
+interface PropertyDef {
+  name: string;
+  type: string;
+}
+
+type TypeDefinition = PropertyDef[];
+
+interface TypedDataTypes {
+  EIP712Domain: TypeDefinition;
+  [typeName: string]: TypeDefinition;
+}
+
+interface TypedData {
+  types: TypedDataTypes;
+  domain: any;
+  primaryType: string;
+  message: any;
+}
+
+interface TypeMapping {
+  [typeName: string]: {
+    [propertyName: string]: string;
+  };
+}
+
+export class TypedDataSanitizerSubprovider extends Subprovider {
+
+  public handleRequest(payload: JSONRPCRequestPayload, next: () => void, end: (error, response) => void) {
+    if (payload.method === 'eth_signTypedData' || payload.method === 'eth_signTypedData_v3') {
+      try {
+        this.sanitizePayload(payload);
+      } catch (err) {
+        return end(err, undefined);
+      }
+    }
+    next();
+  }
+
+  protected sanitizePayload(payload) {
+    const typedData = this.extractTypedData(payload);
+    // create map of types
+    const typeMapping = createTypeMapping(typedData);
+    // sanitize domain
+    sanitizeDomain(typedData, typeMapping);
+    // sanitize message
+    sanitizeMessage(typedData, typeMapping);
+    // Re-assign typed data to params in case it has been parsed
+    // from a string.
+    payload.params[1] = typedData;
+  }
+
+  // Given a JSON-RPC request, extract the typed data from the params
+  protected extractTypedData(payload: JSONRPCRequestPayload): TypedData {
+    if (!payload.params || payload.params.length < 2) {
+      throw ProviderError.InvalidRequest('Missing params for typed data');
+    }
+    // Some implementations pass typed data as a string
+    if (typeof payload.params[1] === 'string') {
+      return JSON.parse(payload.params[1]);
+    }
+    return payload.params[1];
+  }
+
+}
+
+/**
+ * Sanitizes the `domain` values from the TypedData
+ *
+ * @param typedData TypedData payload
+ * @param typeMapping a TypeMapping pre-generated from the TypedData
+ */
+export function sanitizeDomain(typedData: TypedData, typeMapping: TypeMapping) {
+  if (typeof typedData.domain === 'undefined') {
+    throw ProviderError.InvalidRequest('Missing domain for typed data');
+  }
+  if (typeof typedData.types.EIP712Domain === 'undefined') {
+    throw ProviderError.InvalidRequest('Missing type definition for domain');
+  }
+  sanitizeType('EIP712Domain', typedData.domain, typeMapping);
+}
+
+/**
+ * Sanitizes the `message` values from the TypedData
+ *
+ * @param typedData TypedData payload
+ * @param typeMapping a TypeMapping pre-generated from the TypedData
+ */
+export function sanitizeMessage(typedData: TypedData, typeMapping: TypeMapping) {
+  if (typeof typedData.message === 'undefined') {
+    throw ProviderError.InvalidRequest('Missing message in typed data');
+  }
+  if (typeof typedData.primaryType !== 'string') {
+    throw ProviderError.InvalidRequest('Missing primary type in typed data');
+  }
+  sanitizeType(typedData.primaryType, typedData.message, typeMapping);
+}
+
+/**
+ * Recursively examines each value and determines type from the type mapping to
+ * format and sanitize the value if needed.
+ *
+ * Currently this will only convert number values into a consistent hex format,
+ * but in the future additional transformations may be necessary.
+ *
+ * @param typeName Name of the type we are starting from
+ * @param values The root object containing the keys and values
+ * @param typeMapping The type mapping that represents this data
+ */
+export function sanitizeType(typeName: string, values: any, typeMapping: TypeMapping) {
+  // For each key in the 'values' object...
+  Object.keys(values).forEach((key) => {
+    // Find the type name associated from the mapping
+    const type = typeMapping[typeName][key];
+    // Check if the type is an array
+    if (isArray(type)) {
+      // find the base type (left side of the brackets)
+      const baseType = type.split('[')[0];
+      // If base type is a struct, iterate through each instance of struct
+      if (typeMapping[baseType]) {
+        if (typeof values[key].length === 'undefined') {
+          throw new TypeError(`Could not parse ${values[key]} for type ${type}. Expected array.`);
+        }
+        // values[key] is expected to be an array, where each element
+        // is an object that represents the struct named baseType.
+        values[key].forEach((itemValues) => {
+          sanitizeType(baseType, itemValues, typeMapping);
+        });
+      } else {
+        // Do nothing with regular array values
+        // int8[], etc should already be strings
+      }
+    } else if (typeMapping[type]) {
+      // If type name is a custom struct, it should live in the type mapping
+      // We need to recursively check the custom types until we get to primitive values
+      sanitizeType(type, values[key], typeMapping);
+    } else if (type.startsWith('uint') || type.startsWith('int')) {
+      // Finally, if we have a primitive type that is a number, we need to encode the numbers as hex
+      values[key] = encodeNumber(values[key], type, true);
+    }
+  });
+}
+
+/**
+ * Returns true if type name indicates that an array
+ * @param typeName solidity type name
+ */
+function isArray(typeName: string): boolean {
+  if (typeName.includes('[') && typeName.includes(']')) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Maps the type definitions from the typed data for easy look-up.
+ * Top level keys represent the structs defined, while top-level values
+ * are an object keyed by property with string values of the type name.
+ *
+ * For example:
+ * {
+ *    EIP712Domain: {
+ *      name: 'string',
+ *      version: 'string',
+ *      chainId: 'uint256'
+ *    }
+ * }
+ * @param typedData The TypedData to map
+ * @returns {TypeMapping} the mapped data schema
+ */
+export function createTypeMapping(typedData: TypedData): TypeMapping {
+  if (typeof typedData.types === 'undefined') {
+    throw ProviderError.InvalidRequest('Missing type definitions for typed data');
+  }
+  // Go through each of the top level keys. These represent the custom types.
+  return Object.keys(typedData.types).reduce((acc, current) => {
+    // Reduce into a new single object
+    // Set a key for each type, reduce array of property names and types to an object
+    acc[current] = typedData.types[current].reduce((acc2, typeDef) => {
+      // For each type, set the key as the property name, and the value as the type name
+      acc2[typeDef.name] = typeDef.type;
+      return acc2;
+    }, {});
+    return acc;
+  }, {});
+}

--- a/packages/provider/src/utils/parse-utils.ts
+++ b/packages/provider/src/utils/parse-utils.ts
@@ -1,0 +1,77 @@
+import BN from 'bn.js';
+
+/**
+ * parseNumber
+ * Converts a value that represents a number into a hex value.
+ * @param arg {string | number | BN} A number value to convert to hex.
+ * Can be a regular number, base-10 string, base-16 string, or BN instance.
+ * @returns {BN} BN instance representing the number
+ *
+ * (Adapted from ethereumjs-abi)
+ */
+function parseNumber(arg: string | number | BN): BN {
+  const type = typeof arg;
+  if (type === 'string') {
+    if (type.substr(0, 2) === '0x') {
+      return new BN(type.substr(2), 16);
+    } else {
+      return new BN(arg, 10);
+    }
+  } else if (type === 'number') {
+    return new BN(arg);
+  } else if (arg.toArray) {
+    // assume this is a BN for the moment, replace with BN.isBN soon
+    return arg;
+  } else {
+    throw new Error('Argument is not a number');
+  }
+}
+
+function parseBitWidth(type: string, offset: number): number {
+  // default to 256 bit if not specified
+  let size = 256;
+  // If type string is longer than offset, parse bits from the type string
+  if (type.length > offset) {
+    size = parseInt(type.substr(offset), 10);
+  }
+  // bit width must be a multiple of 8, and in the range 8-256.
+  if (size % 8 || size < 8 || size > 256) {
+    throw new Error(`Invalid bit width ${type}`);
+  }
+  return size;
+}
+/**
+ * encodeNumber
+ * Takes a decimal string, hex string, regular number, or BN instance and returns a hex string in the specified format.
+ * Typically these conversions are done in web3, but until web3 adds direct support, this is necessary for normalizing
+ * numbers eth_signTypedData payloads.
+ * @param num The value to convert
+ * @param type The solidity ABI type to format the data as (eg. uint256, int8, etc). Only supports int and uint variants.
+ * @param compact boolean (default false). Whether to use compact encoding for uints, or pad with zeroes.
+ * @returns {string} A hex string formatted as the specified type.
+ */
+export function encodeNumber(num: string | number | BN, type: string, compact: boolean = false): string {
+  if (type.startsWith('uint')) {
+    const size = parseBitWidth(type, 4); // start after 'uint'
+    const length = size / 4; // length in characters for the string. hex is 1 character for 4 bits.
+    const parsed = parseNumber(num);
+    // uint can never be negative
+    if (parsed.isNeg()) {
+      throw new Error('Supplied uint is negative');
+    }
+    // Convert to hex, and prepend 0x
+    if (compact) {
+      return '0x' + parsed.toString(16);
+    }
+    return '0x' + parsed.toString(16, length);
+  } else if (type.startsWith('int')) {
+    // bit width must be a multiple of 8, and in the range 8-256.
+    const size = parseBitWidth(type, 3);
+    const length = size / 4; // length in characters for the string. hex is 1 character for 4 bits.
+    const parsed = parseNumber(num);
+    // Convert to twos complement at the bit size from the type, then convert value to hex
+    return '0x' + parsed.toTwos(size).toString(16, length);
+  } else {
+    throw new Error('Invalid type passed');
+  }
+}

--- a/packages/provider/tests/bitski-engine.test.ts
+++ b/packages/provider/tests/bitski-engine.test.ts
@@ -11,18 +11,29 @@ function createEngine(opts?: BitskiEngineOptions): BitskiEngine {
   return engine;
 }
 
+function findProvider(engine, name) {
+  let matchingProvider;
+  engine._providers.forEach((provider) => {
+    if (provider.constructor.name === name) {
+      matchingProvider = provider;
+      return;
+    }
+  });
+  return matchingProvider;
+}
+
 describe('initialization', () => {
   test('it exists', () => {
     expect.assertions(2);
     const engine = createEngine();
     expect(engine).toBeDefined();
-    expect(engine._providers.length).toBe(8);
+    expect(engine._providers.length).toBe(9);
   });
 
   test('it respects disableCaching option', () => {
     expect.assertions(1);
     const engine = createEngine({ disableCaching: true });
-    expect(engine._providers.length).toBe(6);
+    expect(engine._providers.length).toBe(7);
   });
 });
 
@@ -55,7 +66,7 @@ describe('when handling subscriptions', () => {
   test('it emits events with subscription id', (done) => {
     expect.assertions(1);
     const engine = createEngine();
-    const subscriptionSubprovider = engine._providers[5];
+    const subscriptionSubprovider = findProvider(engine, 'SubscriptionSubprovider');
     const notification = {
       jsonrpc: '2.0',
       method: 'eth_subscription',
@@ -76,7 +87,7 @@ describe('when handling subscriptions', () => {
   test('it re-emits data events for backwards compatibility', (done) => {
     expect.assertions(1);
     const engine = createEngine();
-    const subscriptionSubprovider = engine._providers[5];
+    const subscriptionSubprovider = findProvider(engine, 'SubscriptionSubprovider');
     const notification = {
       jsonrpc: '2.0',
       method: 'eth_subscription',
@@ -97,7 +108,7 @@ describe('when handling subscriptions', () => {
   test('it does not emit subscription id events when receiving invalid data', (done) => {
     expect.assertions(1);
     const engine = createEngine();
-    const subscriptionSubprovider = engine._providers[5];
+    const subscriptionSubprovider = findProvider(engine, 'SubscriptionSubprovider');
     let called = false;
     engine.on('0x1', () => {
       called = true;

--- a/packages/provider/tests/typed-data.test.ts
+++ b/packages/provider/tests/typed-data.test.ts
@@ -1,0 +1,497 @@
+import { ProviderError, ProviderErrorCode } from '../src/errors/provider-error';
+import { createTypeMapping, sanitizeDomain, sanitizeMessage, TypedDataSanitizerSubprovider } from '../src/subproviders/typed-data';
+
+describe('creating a mapping schema', () => {
+  test('Can create a simple schema', () => {
+    expect(6);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'bytes32' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: '0xf00',
+      },
+    };
+    const mapping = createTypeMapping(typedData);
+    expect(mapping.EIP712Domain).toBeDefined();
+    expect(mapping.EIP712Domain.name).toBe('string');
+    expect(mapping.EIP712Domain.chainId).toBe('uint256');
+    expect(mapping.TestStruct).toBeDefined();
+    expect(mapping.TestStruct.title).toBe('string');
+    expect(mapping.TestStruct.value).toBe('bytes32');
+  });
+
+  test('can create a schema with nested structs', () => {
+    expect(5);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'TestNestedStruct' },
+        ],
+        TestNestedStruct: [
+          { name: 'name', type: 'string' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: {
+          name: 'Foo',
+        },
+      },
+    };
+    const mapping = createTypeMapping(typedData);
+    expect(mapping.TestStruct).toBeDefined();
+    expect(mapping.TestStruct.title).toBe('string');
+    expect(mapping.TestStruct.value).toBe('TestNestedStruct');
+    expect(mapping.TestNestedStruct).toBeDefined();
+    expect(mapping.TestNestedStruct.name).toBe('string');
+  });
+
+  test('it throws an error if missing data', () => {
+    expect.assertions(2);
+    const typedData = {
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: {
+          name: 'Foo',
+        },
+      },
+    };
+    try {
+      // @ts-ignore
+      createTypeMapping(typedData);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    }
+  });
+});
+
+describe('sanitizing the domain object', () => {
+  test('it sanitizes numbers in domain into hex strings', () => {
+    expect(2);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'TestNestedStruct' },
+        ],
+        TestNestedStruct: [
+          { name: 'name', type: 'string' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: {
+          name: 'Foo',
+        },
+      },
+    };
+    const mapping = createTypeMapping(typedData);
+    sanitizeDomain(typedData, mapping);
+    expect(typedData.domain.name).toBe('Test Domain');
+    expect(typedData.domain.chainId).toBe('0x1');
+  });
+
+  test('it throws errors if required data is not present', () => {
+    expect.assertions(4);
+    // Missing domain values
+    const noDomainObject = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'TestNestedStruct' },
+        ],
+        TestNestedStruct: [
+          { name: 'name', type: 'string' },
+        ],
+      },
+    };
+    const mapping = {};
+
+    try {
+      // @ts-ignore
+      sanitizeDomain(noDomainObject, mapping);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    }
+
+    // Missing type definition for EIP712Domain
+    const noDomainTypeObject = {
+      types: {
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'string' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: 'Foo',
+      },
+    };
+    try {
+      // @ts-ignore
+      sanitizeDomain(noDomainTypeObject, mapping);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    }
+  });
+});
+
+describe('sanitizing the message object', () => {
+
+  test('it sanitizes numbers in message into hex strings', () => {
+    expect(2);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'favNumber', type: 'int16'},
+          { name: 'value', type: 'TestNestedStruct' },
+        ],
+        TestNestedStruct: [
+          { name: 'name', type: 'string' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        favNumber: 42,
+        value: {
+          name: 'Foo',
+        },
+      },
+    };
+    const mapping = createTypeMapping(typedData);
+    sanitizeMessage(typedData, mapping);
+    expect(typedData.message.favNumber).toBe('0x002a');
+    expect(typedData.message.title).toBe('Hello World');
+  });
+
+  test('it sanitizes numbers in nested struct into hex strings', () => {
+    expect(2);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'TestNestedStruct' },
+        ],
+        TestNestedStruct: [
+          { name: 'favNumber', type: 'uint16'},
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: {
+          favNumber: 42,
+        },
+      },
+    };
+    const mapping = createTypeMapping(typedData);
+    sanitizeMessage(typedData, mapping);
+    expect(typedData.message.value.favNumber).toBe('0x2a');
+    expect(typedData.message.title).toBe('Hello World');
+  });
+
+  test('it sanitizes numbers in arrays of custom structs', () => {
+    expect(3);
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'TestNestedStruct[]' },
+        ],
+        TestNestedStruct: [
+          { name: 'favNumber', type: 'uint16'},
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: [
+          {
+            favNumber: 42,
+          },
+          {
+            favNumber: 128,
+          },
+        ],
+      },
+    };
+
+    const mapping = createTypeMapping(typedData);
+    sanitizeMessage(typedData, mapping);
+    expect(typedData.message.value[0].favNumber).toBe('0x2a');
+    expect(typedData.message.value[1].favNumber).toBe('0x80');
+    expect(typedData.message.title).toBe('Hello World');
+  });
+
+  test('it throws errors when sanitizing bad data', () => {
+    expect.assertions(4);
+    const mapping = {};
+
+    // Missing `message` key
+    const noMessageData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'bytes32' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+    };
+
+    try {
+      // @ts-ignore
+      sanitizeMessage(noMessageData, mapping);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    }
+
+    // Missing `primaryType` key
+    const noPrimaryTypeData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'bytes32' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      message: {
+        title: 'Hello World',
+        value: '0xf00',
+      },
+    };
+    try {
+      // @ts-ignore
+      sanitizeMessage(noPrimaryTypeData, mapping);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    }
+  });
+});
+
+describe('handling JSON-RPC requests', () => {
+
+  const provider = new TypedDataSanitizerSubprovider();
+
+  test('it ignores requests that are not for typed data', () => {
+    const payload = { jsonrpc: '2.0', id: 0, method: 'eth_blockNumber', params: [] };
+    const next = jest.fn();
+    const end = jest.fn();
+    // @ts-ignore
+    const spy = jest.spyOn(provider, 'sanitizePayload');
+    provider.handleRequest(payload, next, end);
+    expect(next).toBeCalled();
+    expect(end).not.toBeCalled();
+    expect(spy).not.toBeCalled();
+  });
+
+  test('it handles typed data requests', () => {
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'uint16' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: 42,
+      },
+    };
+    const payload = { jsonrpc: '2.0', id: 0, method: 'eth_signTypedData', params: ['0xf00', typedData] };
+    const next = jest.fn();
+    const end = jest.fn();
+    // @ts-ignore
+    const spy = jest.spyOn(provider, 'sanitizePayload');
+    provider.handleRequest(payload, next, end);
+    expect(next).toBeCalled();
+    expect(end).not.toBeCalled();
+    expect(spy).toBeCalled();
+    expect(typedData.message.value).toBe('0x2a');
+  });
+
+  test('it handles v3 suffix', () => {
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'uint16' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: 42,
+      },
+    };
+    const payload = { jsonrpc: '2.0', id: 0, method: 'eth_signTypedData_v3', params: ['0xf00', typedData] };
+    const next = jest.fn();
+    const end = jest.fn();
+    // @ts-ignore
+    const spy = jest.spyOn(provider, 'sanitizePayload');
+    provider.handleRequest(payload, next, end);
+    expect(next).toBeCalled();
+    expect(end).not.toBeCalled();
+    expect(spy).toBeCalled();
+    expect(typedData.message.value).toBe('0x2a');
+  });
+
+  test('it handles strings passed in for params', () => {
+    const typedData = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+        ],
+        TestStruct: [
+          { name: 'title', type: 'string' },
+          { name: 'value', type: 'uint16' },
+        ],
+      },
+      domain: {
+        name: 'Test Domain',
+        chainId: 1,
+      },
+      primaryType: 'TestStruct',
+      message: {
+        title: 'Hello World',
+        value: 42,
+      },
+    };
+    const payload = { jsonrpc: '2.0', id: 0, method: 'eth_signTypedData', params: ['0xf00', JSON.stringify(typedData)] };
+    const next = jest.fn();
+    const end = jest.fn();
+    // @ts-ignore
+    const spy = jest.spyOn(provider, 'sanitizePayload');
+    provider.handleRequest(payload, next, end);
+    expect(next).toBeCalled();
+    expect(end).not.toBeCalled();
+    expect(spy).toBeCalled();
+    // @ts-ignore
+    expect(payload.params[1].message.value).toBe('0x2a');
+  });
+
+  test('it throws errors when params are missing', () => {
+    const payload = { jsonrpc: '2.0', id: 0, method: 'eth_signTypedData_v3', params: ['0xf00'] };
+    const next = jest.fn();
+    const end = jest.fn();
+    // @ts-ignore
+    const spy = jest.spyOn(provider, 'sanitizePayload');
+    provider.handleRequest(payload, next, end);
+    expect(next).not.toBeCalled();
+    expect(end).toBeCalled();
+    const error = end.mock.calls[0][0];
+    expect(error).toBeInstanceOf(ProviderError);
+    expect(error.code).toBe(ProviderErrorCode.InvalidRequest);
+    expect(spy).toBeCalled();
+  });
+});


### PR DESCRIPTION
Adds support for EIP-712 by adding support for 'eth_signTypedData' RPC method. When called, this will trigger a permission prompt to the user like other types of signatures.

- Add `eth_signTypedData` and `eth_signTypedData_v3` to authorized method list
- Add `TransactionKind.SignTypedData` enum case, represented as 'ETH_SIGN_TYPED_DATA'
- Add `TypedDataPayload` and `TypedDataDefinition` types to represent the new payload type
- Convert params from `eth_signTypedData` and `eth_signTypedData_v3` to the new payload type