### PR TITLE
Allow passing sign in options via connect button

### DIFF
--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -3,7 +3,7 @@ import { BitskiEngine, BitskiEngineOptions, Kovan, Mainnet, Network, Rinkeby } f
 import { LOGIN_HINT_SIGNUP, SignInOptions } from './auth/oauth-manager';
 import { OpenidAuthProvider } from './auth/openid-auth-provider';
 import { User } from './auth/user';
-import { ConnectButton, ConnectButtonSize } from './components/connect-button';
+import { ConnectButton, ConnectButtonOptions, ConnectButtonSize } from './components/connect-button';
 import { SDK_VERSION } from './constants';
 import { BitskiBrowserEngine } from './providers/bitski-browser-engine';
 import css from './styles/index';
@@ -27,7 +27,8 @@ export { SignInOptions, LOGIN_HINT_SIGNUP };
 // Networks
 export { Network, Mainnet, Rinkeby, Kovan };
 
-export { ConnectButtonSize };
+// Connect Button
+export { ConnectButtonSize, ConnectButtonOptions };
 
 export interface BitskiSDKOptions {
   configuration?: AuthorizationServiceConfiguration;
@@ -113,20 +114,11 @@ export class Bitski {
    * Creates a sign in with bitski button to add to your app. If an HTML element is passed in as the
    * first parameter, it will automatically add it to the DOM inside that element. Make sure to add
    * a callback to get notified of login events.
-   * @param options Optionally provide options for the button
-   * @param options.container Existing dom element to embed the Bitski connect button
-   * @param options.size ConnectButtonSize of button to generate. Defaults to Medium.
-   * @param options.authMethod Login method to use. Defaults to popup.
+   * @param options {ConnectButtonOptions} Optional configuration for the button
    * @param callback Post-login callback. Called when sign in is complete. Not applicable for redirect login method.
    */
-  public getConnectButton(options?: any, callback?: (error?: Error, user?: any) => void): ConnectButton {
-    let settings = {
-      authMethod: OAuthSignInMethod.Popup,
-      container: undefined,
-      size: ConnectButtonSize.Medium,
-    };
-    settings = Object.assign(settings, options);
-    return new ConnectButton(this.authProvider, settings.container, settings.size, settings.authMethod, callback);
+  public getConnectButton(options?: ConnectButtonOptions, callback?: (error?: Error, user?: any) => void): ConnectButton {
+    return new ConnectButton(this.authProvider, options, callback);
   }
 
   /**

--- a/packages/browser/tests/connect-button.test.ts
+++ b/packages/browser/tests/connect-button.test.ts
@@ -1,6 +1,6 @@
 import { OpenidAuthProvider } from '../src/auth/openid-auth-provider';
 import { OAuthSignInMethod } from '../src/bitski';
-import { ConnectButton, ConnectButtonSize } from '../src/components/connect-button';
+import { ConnectButton, ConnectButtonSize, ConnectButtonOptions } from '../src/components/connect-button';
 
 const clientID = 'test-client-id';
 
@@ -9,13 +9,13 @@ function createAuthProvider(): OpenidAuthProvider {
 }
 test('it sets small attributes', () => {
   const authProvider = createAuthProvider();
-  const button = new ConnectButton(authProvider, undefined, ConnectButtonSize.Small);
+  const button = new ConnectButton(authProvider, { size: ConnectButtonSize.Small });
   expect(button.element.classList.contains('size-small')).toBe(true);
 });
 
 test('it sets large attributes', () => {
   const authProvider = createAuthProvider();
-  const button = new ConnectButton(authProvider, undefined, ConnectButtonSize.Large);
+  const button = new ConnectButton(authProvider, { size: ConnectButtonSize.Large });
   expect(button.element.classList.contains('size-large')).toBe(true);
 });
 
@@ -28,7 +28,7 @@ test('it defaults to medium', () => {
 test('it inserts itself into an existing HTMLElement', () => {
   const element = document.createElement('div');
   const authProvider = createAuthProvider();
-  const button = new ConnectButton(authProvider, element);
+  const button = new ConnectButton(authProvider, { container: element });
   expect(element.firstChild).toBe(button.element);
 });
 
@@ -54,7 +54,7 @@ test('it calls the callback on success', (done) => {
     expect(user).toBeDefined();
     done();
   };
-  const button = new ConnectButton(authProvider, undefined, undefined, undefined, callback);
+  const button = new ConnectButton(authProvider, undefined, callback);
   button.signin();
 });
 
@@ -74,8 +74,21 @@ test('it calls the callback on error', (done) => {
 test('it uses provided authentication mode', (done) => {
   expect.assertions(1);
   const authProvider = createAuthProvider();
-  const button = new ConnectButton(authProvider, undefined, undefined, OAuthSignInMethod.Redirect);
+  const button = new ConnectButton(authProvider, { authMethod: OAuthSignInMethod.Redirect });
   jest.spyOn(authProvider, 'signIn').mockImplementation((method) => {
+    expect(method).toBe(OAuthSignInMethod.Redirect);
+    done();
+    return Promise.resolve();
+  });
+  button.signin();
+});
+
+test('it passes provided sign in options', (done) => {
+  expect.assertions(2);
+  const authProvider = createAuthProvider();
+  const button = new ConnectButton(authProvider, { authMethod: OAuthSignInMethod.Redirect, signInOptions: { login_hint: 'signup' } });
+  jest.spyOn(authProvider, 'signIn').mockImplementation((method, options) => {
+    expect(options.login_hint).toBe('signup');
     expect(method).toBe(OAuthSignInMethod.Redirect);
     done();
     return Promise.resolve();


### PR DESCRIPTION
- Define an actual interface for ConnectButtonOptions
- Add option for including SignInOptions with your Connect Button configuration

This is primarily useful for defaulting to sign up from the connect button. We currently expose this only for hitting signIn() directly.