### PR TITLE
Add explicit cancellation handler for connect button

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -238,8 +238,13 @@ _Note: In order for the popup window to properly open in most browsers, this nee
 
 #### Using the Bitski connect button
 
-For your convenience we provide a connect button that you can drop into your page that will trigger the sign in behavior automatically. Here's an example of how you might set that up:
+For your convenience we provide a connect button that you can drop into your page that will trigger the sign in behavior automatically when clicked.
 
+```
+const btnInstance = bitski.getConnectButton([options][, callback]);
+```
+
+Here's an example of how you might set that up:
 ```html
 <!-- my-app.html -->
 <div id="bitski-button"></div>
@@ -259,11 +264,19 @@ function checkAuthStatus() {
     //create the connect button
     const containerElement = document.querySelector('#bitski-button');
     const connectButton = bitski.getConnectButton({ container: containerElement });
-    connectButton.callback = function(error, user) {
+    connectButton.callback = (error, user) => {
+      if (error) {
+        // Handle errors
+        return;
+      }
       //Logged in!
       connectButton.remove();
       continueToApp();
-    }
+    };
+    // Optionally handle cancellation
+    connectButton.onCancel = () => {
+      // Will be called when the user clicks sign in, but dismisses popup
+    };
   } else {
     //already logged in
     continueToApp();
@@ -275,12 +288,14 @@ window.addEventListener('load', () => {
 });
 ```
 
-There are a few optional options you can pass in:
+There are a few options you can pass in. These are not required, but allow you to customize the experience:
 
 - container: An HTML element that you want to inject the button into. If you don't pass anything in you can inject it yourself by accessing the button's element key.
 - size: The size of the button. 'SMALL', 'MEDIUM', or 'LARGE'. Default is 'MEDIUM'.
 - authMethod: The sign in method to use. 'POPUP' or 'REDIRECT'. Default is 'POPUP'.
 - signInOptions: The options to pass during the sign in request (currently, only login_hint is supported. See above.)
+
+Note that the `callback` will be called for either successful or failed login attempts. To handle the case where the user cancels part way through, set the `onCancel` handler.
 
 #### Signing in with redirect
 

--- a/packages/browser/tests/connect-button.test.ts
+++ b/packages/browser/tests/connect-button.test.ts
@@ -1,5 +1,5 @@
 import { OpenidAuthProvider } from '../src/auth/openid-auth-provider';
-import { OAuthSignInMethod } from '../src/bitski';
+import { OAuthSignInMethod, AuthenticationError } from '../src/bitski';
 import { ConnectButton, ConnectButtonSize, ConnectButtonOptions } from '../src/components/connect-button';
 
 const clientID = 'test-client-id';
@@ -68,6 +68,19 @@ test('it calls the callback on error', (done) => {
     done();
   };
   button.callback = callback;
+  button.signin();
+});
+
+test('it calls the onCancel callback on cancellation', (done) => {
+  expect.assertions(1);
+  const authProvider = createAuthProvider();
+  const button = new ConnectButton(authProvider);
+  const spy = jest.spyOn(authProvider, 'signIn').mockRejectedValue(AuthenticationError.UserCancelled());
+  const callback = () => {
+    expect(spy).toBeCalled();
+    done();
+  };
+  button.onCancel = callback;
   button.signin();
 });
 


### PR DESCRIPTION
Instead of returning an error in the standard callback, this will call a separate callback (if specified) when the popup is dismissed.

We could also add additional context to the regular callback instead (maybe if both error and user are undefined), but I thought it might be better to be explicit.

- Assuming most people will not need or want to handle cancellation state
- More intuitive to assume that the callback will include either an error or a user