### PR TITLE
Detect when the popup is blocked

### DIFF
--- a/packages/browser/src/errors/authentication-error.ts
+++ b/packages/browser/src/errors/authentication-error.ts
@@ -12,6 +12,8 @@ export enum AuthenticationErrorCode {
   ServerError = 1004,
   // The SDK is configured incorrectly
   InvalidConfiguration = 1005,
+  // Popup blocked
+  PopupBlocked = 1006,
 }
 
 /**
@@ -37,6 +39,12 @@ export class AuthenticationError extends Error {
   // throw AuthenticationError.UnsupportedAuthenticationMethod()
   public static UnsupportedAuthenticationMethod() {
     return new AuthenticationError('Sign in method not supported.', AuthenticationErrorCode.UnsupportedAuthenticationMethod);
+  }
+
+  // throw AuthenticationError.PopupBlocked()
+  public static PopupBlocked(baseUrl: string) {
+    const msg = `The popup was blocked. Please make sure ${baseUrl} is allowed to open popups.`;
+    return new AuthenticationError(msg, AuthenticationErrorCode.PopupBlocked);
   }
 
   // throw Authentication Error.ServerError(message, description)

--- a/packages/browser/src/utils/popup-validator.ts
+++ b/packages/browser/src/utils/popup-validator.ts
@@ -1,0 +1,42 @@
+/**
+ * A simple utility class that will check to see if a popup is blocked.
+ * Derived from info and examples on this page:
+ * https://stackoverflow.com/questions/2914/how-can-i-detect-if-a-browser-is-blocking-a-popup
+ */
+export class PopupValidator {
+  // Will be called if the popup is blocked
+  protected errorHandler: () => void;
+
+  constructor(errorHandler: () => void) {
+    this.errorHandler = errorHandler;
+  }
+
+  // Check a popup window to see if it has been blocked.
+  // The error handler will be called asynchronously if
+  // the window has been detected to have been blocked.
+  public check(popup: Window | null) {
+    if (popup) {
+      if (/chrome/.test(navigator.userAgent.toLowerCase())) {
+        setTimeout(() => {
+          this.isPopupBlocked(popup);
+        }, 200);
+      } else {
+        popup.onload = () => {
+          this.isPopupBlocked(popup);
+        };
+      }
+    } else {
+        this.handleBlocked();
+    }
+  }
+
+  protected isPopupBlocked(popup: Window) {
+    if ((popup.innerHeight > 0) === false) {
+      this.handleBlocked();
+    }
+  }
+
+  protected handleBlocked() {
+    this.errorHandler();
+  }
+}


### PR DESCRIPTION
This should make it easier to debug issues with the popup being blocked, by returning an error when the popup is blocked. As we move more pieces of our UX to rely on popups, this will become even more critical to get right.