### PR TITLE
Add option to customize storage interface

### DIFF
--- a/packages/browser/src/auth/openid-auth-provider.ts
+++ b/packages/browser/src/auth/openid-auth-provider.ts
@@ -15,19 +15,18 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
     public signOutCallback?: () => void;
 
     constructor(clientId: string, redirectUri: string, additionalScopes?: string[], opts?: BitskiSDKOptions) {
-        let settings: OAuthManagerOptions = {
+        opts = opts || {};
+
+        const settings: OAuthManagerOptions = {
             additionalScopes,
             clientId,
             redirectUri,
         };
-
-        if (opts) {
-            settings = Object.assign(settings, opts);
-        }
+        Object.assign(settings, opts);
 
         this.oauthManager = new OAuthManager(settings);
-        this.tokenStore = new TokenStore(clientId);
-        this.userStore = new UserStore(clientId);
+        this.tokenStore = new TokenStore(clientId, opts.store);
+        this.userStore = new UserStore(clientId, opts.store);
     }
 
     public get authStatus(): AuthenticationStatus {

--- a/packages/browser/src/auth/user-store.ts
+++ b/packages/browser/src/auth/user-store.ts
@@ -1,4 +1,6 @@
 import { USER_KEY } from '../constants';
+import { LocalStorageStore } from '../utils/localstorage-store';
+import { Store } from '../utils/store';
 import { User } from './user';
 
 export class UserStore {
@@ -11,11 +13,13 @@ export class UserStore {
     return `${USER_KEY}.${this.clientId}`;
   }
 
+  protected store: Store;
   protected clientId: string;
   protected user?: User;
 
-  constructor(clientId: string) {
+  constructor(clientId: string, store?: Store) {
     this.clientId = clientId;
+    this.store = store || new LocalStorageStore();
     this.user = this.fetchUser();
   }
 
@@ -30,7 +34,7 @@ export class UserStore {
   }
 
   protected fetchUser(): User | undefined {
-    const userData = localStorage.getItem(this.storageKey);
+    const userData = this.store.getItem(this.storageKey);
     if (userData) {
       return User.fromString(userData);
     }
@@ -38,9 +42,9 @@ export class UserStore {
 
   protected cacheUser(user: User | undefined) {
     if (user) {
-      localStorage.setItem(this.storageKey, user.toStorageString());
+      this.store.setItem(this.storageKey, user.toStorageString());
     } else {
-      localStorage.removeItem(this.storageKey);
+      this.store.clearItem(this.storageKey);
     }
   }
 

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -8,6 +8,8 @@ import { SDK_VERSION } from './constants';
 import { BitskiBrowserEngine } from './providers/bitski-browser-engine';
 import css from './styles/index';
 import { processCallback } from './utils/callback';
+import { LocalStorageStore } from './utils/localstorage-store';
+import { Store } from './utils/store';
 
 export enum OAuthSignInMethod {
   Redirect = 'REDIRECT',
@@ -20,6 +22,9 @@ export enum AuthenticationStatus {
   Expired = 'EXPIRED',
   NotConnected = 'NOT_CONNECTED',
 }
+
+// Customize token and user caching
+export { Store, LocalStorageStore };
 
 // Sign-in Options
 export { SignInOptions, LOGIN_HINT_SIGNUP };
@@ -36,7 +41,10 @@ export { ParseError, ParseErrorCode } from './errors/parse-error';
 export { SignerError, SignerErrorCode } from './errors/signer-error';
 
 export interface BitskiSDKOptions {
+  // Customize oauth configuration
   configuration?: AuthorizationServiceConfiguration;
+  // Customize how tokens and user data are stored.
+  store?: Store;
 }
 
 export interface ProviderOptions extends BitskiEngineOptions {

--- a/packages/browser/src/utils/localstorage-store.ts
+++ b/packages/browser/src/utils/localstorage-store.ts
@@ -1,0 +1,29 @@
+import { Store } from './store';
+
+// Default implementation of generic store interface.
+// Uses localStorage or sessionStorage (pass which one you want in constructor).
+export class LocalStorageStore implements Store {
+
+  protected storage: Storage;
+
+  constructor(storage: Storage = localStorage) {
+    this.storage = storage;
+  }
+
+  public clear() {
+    this.storage.clear();
+  }
+
+  public getItem(key: string): any {
+    return this.storage.getItem(key);
+  }
+
+  public setItem(key: string, value: any) {
+    this.storage.setItem(key, value);
+  }
+
+  public clearItem(key: string) {
+    this.storage.removeItem(key);
+  }
+
+}

--- a/packages/browser/src/utils/store.ts
+++ b/packages/browser/src/utils/store.ts
@@ -1,0 +1,15 @@
+// A generic interface for caching values. Allows for more
+// flexibility in storing access tokens and other persistent data.
+export interface Store {
+  // Empty the cache
+  clear();
+
+  // Get an item from the cache
+  getItem(key): any;
+
+  // Set an item in the cache
+  setItem(key, value);
+
+  // Remove the key from the cache
+  clearItem(key);
+}


### PR DESCRIPTION
This adds the ability to customize caching behavior for your app. We offer 2 built in options: localStorage (default) and sessionStorage for caching your sessions.

```javascript
// Example: Use session storage instead of local storage
import { Bitski, LocalStorageStore } from 'bitski';
const store = new LocalStorageStore(sessionStorage);
const opts = { store };
const bitski = new Bitski('CLIENT-ID', 'REDIRECT-URL', undefined, opts);
```

The Store interface allows you to create completely custom wrappers around whatever suits your app's needs.

```typescript
// Example: create an in-memory store
import { Bitski, Store } from 'bitski';

class MemoryStore implements Store {
  protected storage: Map<string, any>;
  constructor() { storage = new Map<string, any>(); }
  // ...
  public getItem(key: string): any { return storage[key]; }
  // ...
}
const store = new MemoryStore();
const bitski = new Bitski('CLIENT-ID', 'REDIRECT-URL', undefined, { store });
```