### PR TITLE
Add Polygon, Mumbai to networks list. Remove Kovan.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/bitski.svg)](https://www.npmjs.com/package/bitski)
 
-The official Bitski Javascript SDK for the browser. Bitski connects your DApp with a user, a wallet, and a connection to the Ethereum blockchain. We currently support mainnet, as well as Kovan and Rinkeby test networks.
+The official Bitski Javascript SDK for the browser. Bitski connects your DApp with a user, a wallet, and a connection to the Ethereum blockchain. We currently support mainnet for Ethereum and Polygon, and Rinkeby and Mumbai test networks respectively.
 
 *Note: These docs are for version 0.4.x. Upgrading from 0.3.x or earlier? Please see our [Migration Guide](https://github.com/BitskiCo/bitski-js/tree/develop/MIGRATING.md)*
 
@@ -116,7 +116,7 @@ const web3 = new Web3(provider);
 const network = await web3.eth.net.getId();
 ```
 
-Unlike Metamask and other dapp browsers, you can request a provider for the network you are on. To use a different network pass in a network name ("rinkeby", "kovan") in the options as the first argument.
+Unlike Metamask and other dapp browsers, you can request a provider for the network you are on. To use a different network pass in a network name ("rinkeby", "polygon", "mumbai") in the options as the first argument.
 
 ```javascript
 const provider = bitski.getProvider({ networkName: 'rinkeby' });

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7121,12 +7121,12 @@ var rpcUrl: string
 
 
 
-<a id="_provider_src_network_.kovan"></a>
+<a id="_provider_src_network_.polygon"></a>
 
-## Kovan
+## Polygon
 
 
-<a id="_provider_src_network_.kovan.chainid-1"></a>
+<a id="_provider_src_network_.polygon.chainid-1"></a>
 
 ####  chainId
 
@@ -7140,13 +7140,13 @@ var chainId: number = 42
 
 
 
-<a id="_provider_src_network_.kovan.rpcurl-1"></a>
+<a id="_provider_src_network_.polygon.rpcurl-1"></a>
 
 ####  rpcUrl
 
 
 ```javascript
-var rpcUrl: string = "https://api.bitski.com/v1/web3/kovan"
+var rpcUrl: string = "https://api.bitski.com/v1/web3/polygon"
 ```
 <small>*Defined in [packages/provider/src/network.ts:18](https://github.com/BitskiCo/bitski-js/blob/master/packages/packages/provider/src/network.ts#L18)*</small>
 

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -2,7 +2,8 @@ import { AuthorizationServiceConfiguration } from '@openid/appauth';
 import {
   BitskiEngine,
   BitskiEngineOptions,
-  Kovan,
+  Polygon,,
+  Mumbai,
   Mainnet,
   Network,
   Rinkeby,
@@ -41,7 +42,7 @@ export { Store, LocalStorageStore };
 export { SignInOptions, LOGIN_HINT_SIGNUP };
 
 // Networks
-export { Network, Mainnet, Rinkeby, Kovan };
+export { Network, Mainnet, Rinkeby, Polygon, Mumbai };
 
 // Connect Button
 export { ConnectButtonSize, ConnectButtonOptions };
@@ -137,9 +138,6 @@ export class Bitski {
       normalizedOptions = options;
     }
     const network = this.networkFromProviderOptions(options);
-    if (network === Kovan && normalizedOptions.minGasPrice == null) {
-      normalizedOptions.minGasPrice = 1;
-    }
     const newProvider = this.createProvider(network, normalizedOptions);
     newProvider.start();
     this.engines.set(JSON.stringify(options), newProvider);
@@ -288,8 +286,10 @@ export class Bitski {
         return Mainnet;
       case 'rinkeby':
         return Rinkeby;
-      case 'kovan':
-        return Kovan;
+      case 'polygon':
+        return Polygon;
+      case 'mumbai':
+        return Mumbai;
       default:
         throw new Error(
           `Unsupported network name ${networkName}. Try passing a \`network\` in the options instead.`,

--- a/packages/browser/tests/bitski.test.ts
+++ b/packages/browser/tests/bitski.test.ts
@@ -108,7 +108,7 @@ describe('managing providers', () => {
   test('should create new provider if one doesnt yet exist', () => {
     const bitski = createInstance();
     expect(bitski.engines.size).toBe(0);
-    const provider = bitski.getProvider('kovan');
+    const provider = bitski.getProvider('polygon');
     provider.on('error', (error) => {});
     expect(bitski.engines.size).toBe(1);
   });
@@ -116,16 +116,16 @@ describe('managing providers', () => {
   test('should not create a new provider if one already exists for that network', () => {
     const bitski = createInstance();
     expect(bitski.engines.size).toBe(0);
-    bitski.getProvider('kovan');
+    bitski.getProvider('polygon');
     expect(bitski.engines.size).toBe(1);
-    bitski.getProvider('kovan');
+    bitski.getProvider('polygon');
     expect(bitski.engines.size).toBe(1);
   });
 
   test('should not stop engine when force logged out', () => {
     expect.assertions(2);
     const bitski = createInstance();
-    const provider = bitski.getProvider('kovan');
+    const provider = bitski.getProvider('polygon');
 
     // Assert the error is passed through
     provider.on('error', (error) => {

--- a/packages/provider/src/bitski-engine.ts
+++ b/packages/provider/src/bitski-engine.ts
@@ -1,10 +1,10 @@
 import {
   BlockCacheSubprovider,
-  default as Web3ProviderEngine,
   DefaultFixtureSubprovider,
   InflightCacheSubprovider,
   SanitizerSubprovider,
   SubscriptionsSubprovider,
+  default as Web3ProviderEngine,
 } from '@bitski/provider-engine';
 
 import { ProviderError } from './errors/provider-error';
@@ -21,7 +21,7 @@ export interface BitskiEngineOptions {
   disableValidation?: boolean;
   // Disable polling for new blocks
   disableBlockTracking?: boolean;
-  // Set a minimum gas price. Useful for chains like Kovan.
+  // Set a minimum gas price.
   minGasPrice?: number;
 }
 

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -2,7 +2,7 @@ export { BitskiEngine, BitskiEngineOptions } from './bitski-engine';
 export { AccessToken } from './auth/access-token';
 export { AccessTokenProvider } from './auth/access-token-provider';
 export { AuthenticatedFetchSubprovider } from './subproviders/authenticated-fetch';
-export { Network, Mainnet, Rinkeby, Kovan } from './network';
+export { Network, Mainnet, Rinkeby, Polygon, Mumbai } from './network';
 export { ServerError } from './errors/server-error';
 export { ProviderError, ProviderErrorCode } from './errors/provider-error';
 

--- a/packages/provider/src/network.ts
+++ b/packages/provider/src/network.ts
@@ -16,7 +16,7 @@ export const Rinkeby: Network = {
 export const Polygon: Network = {
   chainId: 137,
   rpcUrl: 'https://api.bitski.com/v1/web3/polygon',
-}
+};
 
 export const Mumbai: Network = {
   chainId: 80001,

--- a/packages/provider/src/network.ts
+++ b/packages/provider/src/network.ts
@@ -13,7 +13,12 @@ export const Rinkeby: Network = {
   rpcUrl: 'https://api.bitski.com/v1/web3/rinkeby',
 };
 
-export const Kovan: Network = {
-  chainId: 42,
-  rpcUrl: 'https://api.bitski.com/v1/web3/kovan',
+export const Polygon: Network = {
+  chainId: 137,
+  rpcUrl: 'https://api.bitski.com/v1/web3/polygon',
+}
+
+export const Mumbai: Network = {
+  chainId: 80001,
+  rpcUrl: 'https://api.bitski.com/v1/web3/mumbai',
 };

--- a/packages/provider/tests/authenticated-fetch.test.ts
+++ b/packages/provider/tests/authenticated-fetch.test.ts
@@ -22,7 +22,7 @@ class MockProvider implements AccessTokenProvider {
 function createFetchProvider(): AuthenticatedFetchSubprovider {
   const tokenProvider = new MockProvider();
   return new AuthenticatedFetchSubprovider(
-    'https://localhost:56610/v1/web3/kovan',
+    'https://localhost:56610/v1/web3/polygon',
     true,
     tokenProvider,
     { 'X-API-KEY': 'test-client-id' },


### PR DESCRIPTION
Add Polygon and Mumbai testnet to networks list so that the SDK can query for chain ID and rpc url based off network name passed to provider.