### PR TITLE
Export User type for consumers using TypeScript

### DIFF
--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -45,6 +45,10 @@ export { SignInOptions, LOGIN_HINT_SIGNUP };
 // Networks
 export { Network, Mainnet, Rinkeby, Polygon, Mumbai };
 
+// Type-only for a User. Can be passed around in TypeScript,
+// but not constructed outside this library.
+export type { User };
+
 // Connect Button
 export { ConnectButtonSize, ConnectButtonOptions };
 


### PR DESCRIPTION
This type is returned by a handful of SDK methods. When consuming from a TypeScript-enabled project, it would be nice to have a reference to the type rather than having to re-implement.