### PR TITLE
Patch vulnerability in async package with update to 3.2.2.

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@bitski/provider-engine": "^0.7.0-beta.2",
     "@openid/appauth": "^1.2.6",
-    "async": "^3.0.0",
+    "async": "^3.2.2",
     "bitski-provider": "^0.14.0",
     "uuid": "^8.0.0"
   },

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@bitski/provider-engine": "^0.7.0-beta.2",
-    "async": "^3.0.1",
+    "async": "^3.2.2",
     "bn.js": "^4.11.8",
     "json-rpc-error": "^2.0.0"
   },


### PR DESCRIPTION
OpenSea flagged us with regards to a vulnerability of this package, updating to patch it: https://github.com/advisories/GHSA-fwr7-v2mv-hh25
