### PR TITLE
Fix double sign error

### DIFF
--- a/.changeset/five-walls-confess.md
+++ b/.changeset/five-walls-confess.md
@@ -1,0 +1,5 @@
+---
+"bitski": patch
+---
+
+Move clearing of state to before callback is called to prevent premature dismissal of subsequent request dialogs. 

--- a/packages/browser/src/signing/transaction-signer.ts
+++ b/packages/browser/src/signing/transaction-signer.ts
@@ -95,6 +95,10 @@ export class BitskiTransactionSigner {
     if (this.currentRequestDialog) {
       this.currentRequestDialog.dismiss();
     }
+    
+    // Clear state
+    this.currentRequest = undefined;
+    this.currentRequestDialog = undefined;
 
     // Call the callback to complete the request
     if (callback.error) {
@@ -102,10 +106,6 @@ export class BitskiTransactionSigner {
     } else {
       fulfill(callback.result);
     }
-
-    // Clear state
-    this.currentRequest = undefined;
-    this.currentRequestDialog = undefined;
   }
 
   /**


### PR DESCRIPTION
When signing two transactions in a row, the second one doesn't fire.

We were clearing the current state after the callback, need to clear it before.