### PR TITLE
Fix: Remove requirement for EIP712Domain

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bitski
 
+## 0.0.0-dvision-20220617033240
+
+### Patch Changes
+
+- Updated dependencies []:
+  - bitski-provider@0.0.0-dvision-20220617033240
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/BitskiCo/bitski-js"
   },
-  "version": "0.15.0",
+  "version": "0.0.0-dvision-20220617033240",
   "scripts": {
     "lint": "eslint . --cache",
     "test": "jest",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@openid/appauth": "^1.2.6",
-    "bitski-provider": "^0.15.0",
+    "bitski-provider": "^0.0.0-dvision-20220617033240",
     "uuid": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bitski-provider
 
+## 0.0.0-dvision-20220617033240
+
+### Minor Changes
+
+- Remove requirement on EIP712Domain for typed data
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/BitskiCo/bitski-js"
   },
-  "version": "0.15.0",
+  "version": "0.0.0-dvision-20220617033240",
   "scripts": {
     "test": "jest",
     "lint": "eslint . --cache",

--- a/packages/provider/src/subproviders/typed-data.ts
+++ b/packages/provider/src/subproviders/typed-data.ts
@@ -12,7 +12,6 @@ interface PropertyDef {
 type TypeDefinition = PropertyDef[];
 
 interface TypedDataTypes {
-  EIP712Domain: TypeDefinition;
   [typeName: string]: TypeDefinition;
 }
 
@@ -53,8 +52,10 @@ export class TypedDataSanitizerSubprovider extends Subprovider {
     const typedData = this.extractTypedData(payload);
     // create map of types
     const typeMapping = createTypeMapping(typedData);
-    // sanitize domain
-    sanitizeDomain(typedData, typeMapping);
+    // sanitize domain if available
+    if (typedData.domain || typedData.types.EIP712Domain) {
+      sanitizeDomain(typedData, typeMapping);
+    }
     // sanitize message
     sanitizeMessage(typedData, typeMapping);
     // Re-assign typed data to params in case it has been parsed
@@ -84,9 +85,6 @@ export class TypedDataSanitizerSubprovider extends Subprovider {
 export function sanitizeDomain(typedData: TypedData, typeMapping: TypeMapping) {
   if (typeof typedData.domain === 'undefined') {
     throw ProviderError.InvalidRequest('Missing domain for typed data');
-  }
-  if (typeof typedData.types.EIP712Domain === 'undefined') {
-    throw ProviderError.InvalidRequest('Missing type definition for domain');
   }
   sanitizeType('EIP712Domain', typedData.domain, typeMapping);
 }


### PR DESCRIPTION
Currently, if EIP712Domain is not provided, we error - however, EIP712Domain is not a required type based on EIP-712:

https://eips.ethereum.org/EIPS/eip-1102

Even Metamask makes these fields optional: https://github.com/MetaMask/eth-sig-util/blob/cde38f7aa3f8e8d0a7ee75730f363325b8e1924c/src/sign-typed-data.ts#L82-L88

This PR removes the requirement for this type, and allows messages to still be signed without any of the fields being provided.