### PR TITLE
Fix add missing BNB name references

### DIFF
--- a/.changeset/funny-peas-notice.md
+++ b/.changeset/funny-peas-notice.md
@@ -1,0 +1,5 @@
+---
+'bitski': patch
+---
+
+Adds missing BNB and BNBT references to get network from name

--- a/packages/browser/src/bitski.ts
+++ b/packages/browser/src/bitski.ts
@@ -301,6 +301,10 @@ export class Bitski {
         return Polygon;
       case 'mumbai':
         return Mumbai;
+      case 'bnb':
+        return BinanceSmartChain;
+      case 'bnbt':
+        return BinanceSmartChainTestnet;
       default:
         throw new Error(
           `Unsupported network name ${networkName}. Try passing a \`network\` in the options instead.`,


### PR DESCRIPTION
Currently SDK is missing references for BNB and BNBT when using network name. This PR fixes it.