### PR TITLE
Extend timeout to prevent popup from being dismissed early in Chromium browsers

### DIFF
--- a/.changeset/hungry-fishes-move.md
+++ b/.changeset/hungry-fishes-move.md
@@ -1,0 +1,5 @@
+---
+'bitski': patch
+---
+
+Extend timeout to prevent popup from being dismissed early in Chromium browsers

--- a/packages/browser/src/-private/utils/popup-validator.ts
+++ b/packages/browser/src/-private/utils/popup-validator.ts
@@ -19,7 +19,7 @@ export class PopupValidator {
       if (/chrome/.test(navigator.userAgent.toLowerCase())) {
         setTimeout(() => {
           this.isPopupBlocked(popup);
-        }, 200);
+        }, 2000);
       } else {
         popup.onload = () => {
           this.isPopupBlocked(popup);


### PR DESCRIPTION
Extend timeout to prevent popup from being dismissed early in Chromium browsers