### PR TITLE
Add method for reloading auth state from cache

### DIFF
--- a/.changeset/twelve-bees-swim.md
+++ b/.changeset/twelve-bees-swim.md
@@ -1,0 +1,5 @@
+---
+'bitski': patch
+---
+
+Add internal method for reloading auth state from cache

--- a/packages/browser/src/-private/auth/openid-auth-provider.ts
+++ b/packages/browser/src/-private/auth/openid-auth-provider.ts
@@ -202,4 +202,9 @@ export class OpenidAuthProvider implements AccessTokenProvider, AuthProvider {
         return user;
       });
   }
+
+  public loadFromCache(): void {
+    this.tokenStore.loadTokensFromCache();
+    this.userStore.loadUserFromCache();
+  }
 }

--- a/packages/browser/src/-private/auth/token-store.ts
+++ b/packages/browser/src/-private/auth/token-store.ts
@@ -37,21 +37,23 @@ export class TokenStore {
     return `${REFRESH_TOKEN_KEY}.${this.clientId}`;
   }
   protected store: Store;
-  protected accessToken: Promise<AccessToken | undefined>;
-  protected refreshToken: Promise<string | undefined>;
-  protected idToken: Promise<string | undefined>;
+  protected accessToken!: Promise<AccessToken | undefined>;
+  protected refreshToken!: Promise<string | undefined>;
+  protected idToken!: Promise<string | undefined>;
   protected clientId: string;
 
   constructor(clientId: string, store?: Store) {
     this.clientId = clientId;
     this.store = store || new LocalStorageStore();
-    this.accessToken = Promise.resolve(this.store.getItem(this.accessTokenKey)).then(
-      (accessTokenString) => {
-        if (accessTokenString) {
-          return AccessToken.fromString(accessTokenString);
-        }
-      },
-    );
+    this.loadTokensFromCache();
+  }
+
+  public loadTokensFromCache(): void {
+    this.accessToken = this.store.getItem(this.accessTokenKey).then((accessTokenString) => {
+      if (accessTokenString) {
+        return AccessToken.fromString(accessTokenString);
+      }
+    });
 
     this.idToken = this.store.getItem(this.idTokenKey);
     this.refreshToken = this.store.getItem(this.refreshTokenKey);

--- a/packages/browser/src/-private/auth/user-store.ts
+++ b/packages/browser/src/-private/auth/user-store.ts
@@ -34,6 +34,10 @@ export class UserStore {
     await this.cacheUser(undefined);
   }
 
+  public loadUserFromCache(): void {
+    this.user = this.fetchUser();
+  }
+
   protected async fetchUser(): Promise<User | undefined> {
     const userData = await this.store.getItem(this.storageKey);
     if (userData) {

--- a/packages/browser/src/-private/sdk.ts
+++ b/packages/browser/src/-private/sdk.ts
@@ -184,6 +184,14 @@ export class BitskiSDK {
     return this.authProvider.signOut();
   }
 
+  /**
+   * Used to refresh the auth provider's state if the user is logged in/out in a
+   * different process
+   */
+  public reloadAuthState(): void {
+    this.authProvider.loadFromCache();
+  }
+
   public createProvider(network: Network, options: ProviderOptions = {}): BitskiBrowserEngine {
     return new BitskiBrowserEngine(
       this.clientId,


### PR DESCRIPTION
Adds a method for refreshing the auth state in memory from the local store. This is useful if you are running the Bitski SDK in multiple processes and need to sync them after a user has logged in/out.