### PR TITLE
Accept mixed up param ordering for personal_sign when recognizable.

### DIFF
--- a/.changeset/beige-eels-rule.md
+++ b/.changeset/beige-eels-rule.md
@@ -1,0 +1,5 @@
+---
+'bitski': minor
+---
+
+Add condition to personal_sign case to recover from wrong param ordering.

--- a/packages/browser/src/-private/subproviders/signature.ts
+++ b/packages/browser/src/-private/subproviders/signature.ts
@@ -294,6 +294,13 @@ export class SignatureSubprovider extends Subprovider {
         }
       case 'personal_sign':
         if (request.params && request.params.length > 1) {
+          // If the first param is a wallet address, flip the parameter ordering for personal_sign
+          // so that it matches eth_sign. This is to gracefully respect Dapps who adopted Metamask's
+          // API for personal_sign early, and recover from the wrong param order
+          // when it is clearly identifiable.
+          if (request.params[0].startsWith('0x') && request.params[0].length === 42) {
+            return { from: request.params[0], message: request.params[1] };
+          }
           return { from: request.params[1], message: request.params[0] };
         } else {
           throw SignerError.MissingMessage();


### PR DESCRIPTION
Follow [similar approach to Metamask](https://github.com/MetaMask/web3-provider-engine/blob/af9060aa44059be92285ae441777bbe5cdb63d71/subproviders/hooked-wallet.js#L159-L191) for handling mixed up param ordering in `personal_sign` by Dapps.