### PR TITLE
Update tokens properly when refreshed

### DIFF
--- a/.changeset/giant-planets-punch.md
+++ b/.changeset/giant-planets-punch.md
@@ -1,0 +1,5 @@
+---
+'bitski': minor
+---
+
+Fix refresh token storage, race conditions, and add `onUpdate` to token store to signal async changes

--- a/packages/browser/src/-private/utils/store.ts
+++ b/packages/browser/src/-private/utils/store.ts
@@ -12,4 +12,6 @@ export interface Store {
 
   // Remove the key from the cache
   clearItem(key: string): Promise<void>;
+
+  onUpdate?(fn: () => void);
 }


### PR DESCRIPTION
- Update refresh token in memory when it has been changed, just like access token and id token
- Add `onUpdate` to token store so that it can signal when a change has occured in another process and update in memory
- Ensure that only one refresh token request occurs at a time (return the same promise to every user of the token)