### PR TITLE
Account for all successful responses in provider shim

### DIFF
--- a/.changeset/cool-squids-play.md
+++ b/.changeset/cool-squids-play.md
@@ -1,0 +1,5 @@
+---
+'bitski-provider': patch
+---
+
+Account for all successful responses in provider shim

--- a/packages/bitski-provider/src/utils/fetch.ts
+++ b/packages/bitski-provider/src/utils/fetch.ts
@@ -62,7 +62,7 @@ export const fetchJsonWithRetry = async (
       },
     });
 
-    if (response.status !== 200) {
+    if (response.ok) {
       switch (response.status) {
         case 405:
           throw ethErrors.rpc.methodNotFound();

--- a/packages/bitski-provider/src/utils/fetch.ts
+++ b/packages/bitski-provider/src/utils/fetch.ts
@@ -62,7 +62,7 @@ export const fetchJsonWithRetry = async (
       },
     });
 
-    if (response.ok) {
+    if (!response.ok) {
       switch (response.status) {
         case 405:
           throw ethErrors.rpc.methodNotFound();


### PR DESCRIPTION
Previously, the provider shim would fail on 201s as a result of posting the transaction. This change should account for all successful responses in a transaction call. 