### PR TITLE
Fix styling for iframe

### DIFF
--- a/.changeset/popular-masks-guess.md
+++ b/.changeset/popular-masks-guess.md
@@ -1,0 +1,5 @@
+---
+'bitski': patch
+---
+
+Separate button style embeded class namespace from iframe style namespace

--- a/packages/bitski/src/-private/sdk.ts
+++ b/packages/bitski/src/-private/sdk.ts
@@ -230,12 +230,12 @@ export class BitskiSDK {
    * Embeds Bitski's UI styles
    */
   protected injectStyles(): void {
-    if (document.getElementById('BitskiSDKEmbeddedStyles')) {
+    if (document.getElementById('BitskiSDKButtonEmbeddedStyles')) {
       return;
     }
     const style = document.createElement('style');
     style.setAttribute('type', 'text/css');
-    style.setAttribute('id', 'BitskiSDKEmbeddedStyles');
+    style.setAttribute('id', 'BitskiSDKButtonEmbeddedStyles');
     style.appendChild(document.createTextNode(css));
     const head = document.head || document.getElementsByTagName('head')[0];
     head.appendChild(style);


### PR DESCRIPTION
Fix styling for iframe by separating the style namespace for the button component from the dialog component. 

Previously, the iframe styling was not properly being injected because the namespace for the button style container was the same and already present, so the injecting of styles for the iframe would do an early return. 