### PR TITLE
Add WAAS config options and signer query params config

### DIFF
--- a/packages/bitski-provider/src/bitski-provider.ts
+++ b/packages/bitski-provider/src/bitski-provider.ts
@@ -65,13 +65,25 @@ export class BitskiProvider<Extra = unknown> implements EthProvider {
   private activeSubs = new Set<string>();
 
   constructor(config: BitskiProviderConfig<Extra>) {
+    const { appId: maybeAppId, clientId } = config;
+
+    const appId = maybeAppId ?? clientId;
+
+    if (!appId) {
+      throw new Error('You must provide an appId to BitskiProvider');
+    } else if (maybeAppId && clientId) {
+      throw new Error('You must provide either an appId or a clientId to BitskiProvider, not both');
+    } else if (clientId) {
+      console.warn('clientId is deprecated, please use appId instead');
+    }
+
     this.config = {
       ...config,
 
       fetch: config.fetch ?? fetch,
       additionalHeaders: {
-        'X-API-KEY': config.clientId,
-        'X-CLIENT-ID': config.clientId,
+        'X-API-KEY': appId,
+        'X-CLIENT-ID': appId,
         'X-CLIENT-VERSION': BITSKI_PROVIDER_VERSION,
         ...(config.additionalHeaders ?? {}),
       },

--- a/packages/bitski-provider/src/types.ts
+++ b/packages/bitski-provider/src/types.ts
@@ -51,10 +51,18 @@ export interface InternalBitskiProviderConfig<Extra = unknown> {
   disableValidation?: boolean;
   additionalSigningContext?: Record<string, string>;
 
-  clientId: string;
+  appId?: string;
+
+  /** @deprecated switch to appId */
+  clientId?: string;
   apiBaseUrl: string;
   signerBaseUrl: string;
   transactionCallbackUrl?: string;
+  signerQueryParams?: URLSearchParams;
+
+  waas?: {
+    userId: string;
+  };
 
   store: BitskiProviderStore;
   sign: SignFn;

--- a/packages/bitski-provider/tests/middlewares/signature.test.ts
+++ b/packages/bitski-provider/tests/middlewares/signature.test.ts
@@ -901,7 +901,7 @@ describe('signature middleware', () => {
       await sleep(10);
 
       expect(window.location.href).toMatch(
-        /https:\/\/sign\.bitski.com\/transactions\/.+\?redirectURI=https:\/\/test.com\/callback/,
+        /https:\/\/sign\.bitski.com\/transactions\/.+\?redirectURI=https%3A%2F%2Ftest.com%2Fcallback/,
       );
 
       window.location = location;


### PR DESCRIPTION
Adds config to our provider for our Wallet-as-a-Service so users can sign without the full SDK. 