### PR TITLE
Feat: Enable provider to hold paymaster data for request context

### DIFF
--- a/.changeset/two-ligers-pay.md
+++ b/.changeset/two-ligers-pay.md
@@ -1,0 +1,6 @@
+---
+'bitski': minor
+'bitski-provider': minor
+---
+
+Add support for paymaster and waas in SDK and transaction context

--- a/packages/bitski-provider/src/bitski-provider.ts
+++ b/packages/bitski-provider/src/bitski-provider.ts
@@ -264,6 +264,8 @@ export class BitskiProvider<Extra = unknown> implements EthProvider {
     const context: RequestContext<Extra> = {
       chain,
       config: this.config,
+      paymaster: this.config.paymaster,
+      waas: this.config.waas,
       store: this.store,
       emit: this.events.emit.bind(this.events),
       extra: opts?.extra,

--- a/packages/bitski-provider/src/signers/browser.ts
+++ b/packages/bitski-provider/src/signers/browser.ts
@@ -58,6 +58,7 @@ export default function createBrowserSigner({ showPopup }: BrowserSignerConfig =
       method,
       params,
       requestContext.chain,
+      requestContext.paymaster,
       requestContext.config.additionalSigningContext,
     );
 

--- a/packages/bitski-provider/src/signers/shared.ts
+++ b/packages/bitski-provider/src/signers/shared.ts
@@ -10,8 +10,12 @@ export const getSignerUrl = (
     searchParams.set('redirectURI', config.transactionCallbackUrl);
   }
 
-  if (config.waas?.userId) {
-    const federatedId = btoa(`${config.appId}:${config.waas.userId}`);
+  if (config.waas) {
+    let federatedId = btoa(`${config.appId}`);
+
+    if (config.waas.userId) {
+      federatedId = btoa(`${config.appId}:${config.waas.userId}`);
+    }
 
     searchParams.set('loginHint', `fa_${federatedId}`);
   }

--- a/packages/bitski-provider/src/types.ts
+++ b/packages/bitski-provider/src/types.ts
@@ -9,7 +9,7 @@ import {
 } from 'eth-provider-types';
 import { JsonRpcRequest, PendingJsonRpcResponse } from 'json-rpc-engine';
 import type { BitskiProviderStateStore } from './store';
-import { PaymasterDefinition } from './utils/transaction';
+import { PaymasterDefinition, WaasDefinition } from './utils/transaction';
 
 export interface User {
   id: string;
@@ -45,7 +45,7 @@ export interface BitskiProviderStore {
 export interface InternalBitskiProviderConfig<Extra = unknown> {
   fetch: typeof fetch;
   additionalHeaders: Record<string, string>;
-
+  paymaster?: PaymasterDefinition;
   prependMiddleware?: ProviderMiddleware<unknown[], unknown, Extra>[];
   pollingInterval?: number;
   disableCaching?: boolean;
@@ -61,10 +61,7 @@ export interface InternalBitskiProviderConfig<Extra = unknown> {
   transactionCallbackUrl?: string;
   signerQueryParams?: URLSearchParams;
 
-  waas?: {
-    userId: string;
-    transactionProxyUrl: string;
-  };
+  waas?: WaasDefinition;
 
   store: BitskiProviderStore;
   sign: SignFn;
@@ -92,6 +89,7 @@ export interface RequestContext<Extra = unknown> {
   // The current chain the request is being made on
   chain: EthChainDefinitionWithRpcUrl;
   paymaster?: PaymasterDefinition;
+  waas?: WaasDefinition;
 
   // The configuration of the provider
   config: InternalBitskiProviderConfig<Extra>;

--- a/packages/bitski-provider/src/types.ts
+++ b/packages/bitski-provider/src/types.ts
@@ -9,6 +9,7 @@ import {
 } from 'eth-provider-types';
 import { JsonRpcRequest, PendingJsonRpcResponse } from 'json-rpc-engine';
 import type { BitskiProviderStateStore } from './store';
+import { PaymasterDefinition } from './utils/transaction';
 
 export interface User {
   id: string;
@@ -90,6 +91,7 @@ export type BitskiProviderConfig<Extra = unknown> = Optional<
 export interface RequestContext<Extra = unknown> {
   // The current chain the request is being made on
   chain: EthChainDefinitionWithRpcUrl;
+  paymaster?: PaymasterDefinition;
 
   // The configuration of the provider
   config: InternalBitskiProviderConfig<Extra>;

--- a/packages/bitski-provider/src/types.ts
+++ b/packages/bitski-provider/src/types.ts
@@ -45,7 +45,7 @@ export interface BitskiProviderStore {
 export interface InternalBitskiProviderConfig<Extra = unknown> {
   fetch: typeof fetch;
   additionalHeaders: Record<string, string>;
-  paymaster?: PaymasterDefinition;
+  paymaster?: PaymasterDefinition | PaymasterDefinition[];
   prependMiddleware?: ProviderMiddleware<unknown[], unknown, Extra>[];
   pollingInterval?: number;
   disableCaching?: boolean;
@@ -88,7 +88,7 @@ export type BitskiProviderConfig<Extra = unknown> = Optional<
 export interface RequestContext<Extra = unknown> {
   // The current chain the request is being made on
   chain: EthChainDefinitionWithRpcUrl;
-  paymaster?: PaymasterDefinition;
+  paymaster?: PaymasterDefinition | PaymasterDefinition[];
   waas?: WaasDefinition;
 
   // The configuration of the provider

--- a/packages/bitski-provider/src/utils/transaction.ts
+++ b/packages/bitski-provider/src/utils/transaction.ts
@@ -36,7 +36,7 @@ export interface WaasDefinition {
 export interface TransactionContext {
   chainId?: number;
   rpcUrl?: string;
-  paymaster?: PaymasterDefinition;
+  paymaster?: PaymasterDefinition | PaymasterDefinition[];
   from?: string;
   [key: string]: unknown;
 }
@@ -54,7 +54,7 @@ export const createBitskiTransaction = <T extends EthSignMethod>(
   method: T,
   params: EthSignMethodParams[T],
   chain: EthChainDefinitionWithRpcUrl,
-  paymaster?: PaymasterDefinition,
+  paymaster?: PaymasterDefinition | PaymasterDefinition[],
   additionalContext?: Record<string, string>,
 ): Transaction => {
   const context = createContext(method, params, chain, paymaster, additionalContext);
@@ -72,7 +72,7 @@ const createContext = <T extends EthSignMethod>(
   method: T,
   params: EthSignMethodParams[T],
   chain: EthChainDefinitionWithRpcUrl,
-  paymaster?: PaymasterDefinition,
+  paymaster?: PaymasterDefinition | PaymasterDefinition[],
   additionalContext?: Record<string, string>,
 ): TransactionContext => {
   switch (method) {

--- a/packages/bitski-provider/src/utils/transaction.ts
+++ b/packages/bitski-provider/src/utils/transaction.ts
@@ -28,6 +28,11 @@ export interface PaymasterDefinition {
   rpcMethod?: string;
 }
 
+export interface WaasDefinition {
+  userId?: string;
+  transactionProxyUrl?: string;
+}
+
 export interface TransactionContext {
   chainId?: number;
   rpcUrl?: string;

--- a/packages/bitski/src/-private/sdk.ts
+++ b/packages/bitski/src/-private/sdk.ts
@@ -24,16 +24,22 @@ export interface BitskiSDKOptions {
   store?: BitskiProviderStore;
 }
 
-export interface Paymaster {
+export interface PaymasterDefinition {
   paymasterUrl: string;
   policyId?: string;
   rpcMethod?: string;
 }
 
+export interface WaasDefinition {
+  userId?: string;
+  transactionProxyUrl?: string;
+}
+
 export interface ProviderOptions extends Omit<Partial<BitskiProviderConfig>, 'prependMiddleware'> {
   networkName?: string;
   network?: Network;
-  paymaster?: Paymaster | Paymaster[];
+  paymaster?: PaymasterDefinition | PaymasterDefinition[];
+  waas?: WaasDefinition;
   // @deprecated
   webBaseUrl?: string;
   // @deprecated

--- a/packages/bitski/src/-private/sdk.ts
+++ b/packages/bitski/src/-private/sdk.ts
@@ -24,10 +24,16 @@ export interface BitskiSDKOptions {
   store?: BitskiProviderStore;
 }
 
+export interface Paymaster {
+  paymasterUrl: string;
+  policyId?: string;
+  rpcMethod?: string;
+}
+
 export interface ProviderOptions extends Omit<Partial<BitskiProviderConfig>, 'prependMiddleware'> {
   networkName?: string;
   network?: Network;
-
+  paymaster?: Paymaster | Paymaster[];
   // @deprecated
   webBaseUrl?: string;
   // @deprecated

--- a/packages/bitski/tests/bitski.test.ts
+++ b/packages/bitski/tests/bitski.test.ts
@@ -84,6 +84,11 @@ describe('managing providers', () => {
         rpcUrl: 'https://api-v2.otl.com/web3/goerli',
         chainId: 4,
       },
+      paymaster: {
+        paymasterUrl: 'https://api-v2.otl.com/paymaster',
+        policyId: '1n123n-1nnlsn9-1012311eee',
+        rpcMethod: 'pm_sponsorTransaction',
+      },
       webBaseUrl: 'https://next.bitski.com',
     });
     expect(provider).toBeDefined();


### PR DESCRIPTION
Goal: Add paymaster property as a provider option to eventually be submitted as request context.

This will end up submitting a transaction with the paymaster data part of the transaction context. 

In signer, if paymaster data is present, we will utilize this instead of our own paymaster and policy for sponsoring transactions. 

Additionally, we will enable settings in Developer Portal to specify paymaster to be used, or set a paymaster based on selected options such as from Stackup, Alchemy, Pimlico, etc. 