### PR TITLE
Fix typescript excluding node_modules types

### DIFF
--- a/.changeset/pretty-coats-yell.md
+++ b/.changeset/pretty-coats-yell.md
@@ -1,0 +1,5 @@
+---
+'@bitski/wagmi-connector': patch
+---
+
+Remove exclusion of node_module types from tsconfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -15147,12 +15147,12 @@
     },
     "packages/wagmi-connector": {
       "name": "@bitski/wagmi-connector",
-      "version": "0.2.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@rainbow-me/rainbowkit": "1.3.3",
-        "@wagmi/core": "1.4.13",
-        "bitski": "^3.8.0",
-        "viem": "1.19.13"
+        "@rainbow-me/rainbowkit": "^1.3.3",
+        "@wagmi/core": "^1.4.13",
+        "bitski": "^3.8.1",
+        "viem": "^1.19.13"
       },
       "devDependencies": {
         "@babel/core": "^7.6.4",
@@ -16757,16 +16757,16 @@
         "@babel/core": "^7.6.4",
         "@babel/plugin-transform-runtime": "^7.6.2",
         "@babel/preset-env": "^7.6.3",
-        "@rainbow-me/rainbowkit": "1.3.3",
+        "@rainbow-me/rainbowkit": "^1.3.3",
         "@testing-library/dom": "^8.19.0",
         "@types/jest": "^27.5.2",
-        "@wagmi/core": "1.4.13",
+        "@wagmi/core": "^1.4.13",
         "babelify": "^10.0.0",
-        "bitski": "^3.8.0",
+        "bitski": "^3.8.1",
         "jest": "27.2.0",
         "jest-fetch-mock": "^3.0.3",
         "ts-jest": "^27.0.5",
-        "viem": "1.19.13"
+        "viem": "^1.19.13"
       },
       "dependencies": {
         "@noble/curves": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "release": "turbo run build && changeset publish"
   },
   "volta": {
-    "node": "16.17.0"
+    "node": "18.17.0"
   },
   "version": "0.0.0",
   "devDependencies": {

--- a/packages/wagmi-connector/tsconfig.json
+++ b/packages/wagmi-connector/tsconfig.json
@@ -16,6 +16,5 @@
     "strict": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Fix typescript excluding node_modules types
Pin node 18 to project to match CI