### PR TITLE
Pass through response from blockchain accounts; or default to contract wallet only on waas config

### DIFF
--- a/.changeset/odd-flies-rush.md
+++ b/.changeset/odd-flies-rush.md
@@ -1,0 +1,5 @@
+---
+'bitski-provider': minor
+---
+
+Return the contract wallet on when waas is passed in config

--- a/.changeset/odd-flies-rush.md
+++ b/.changeset/odd-flies-rush.md
@@ -2,4 +2,4 @@
 'bitski-provider': minor
 ---
 
-Return the contract wallet on when waas is passed in config
+Allow blockchain accounts to handle filtering of account type instead; accept response passthrough.

--- a/.changeset/odd-flies-rush.md
+++ b/.changeset/odd-flies-rush.md
@@ -2,4 +2,4 @@
 'bitski-provider': minor
 ---
 
-Allow blockchain accounts to handle filtering of account type instead; accept response passthrough.
+Allow blockchain accounts to handle eth_accounts filtering of account type instead if only one account; otherwise, only prioritize contract wallets in eth_accounts if WaaS config is enabled.

--- a/.changeset/odd-flies-rush.md
+++ b/.changeset/odd-flies-rush.md
@@ -2,4 +2,4 @@
 'bitski-provider': minor
 ---
 
-Allow blockchain accounts to handle eth_accounts filtering of account type instead if only one account; otherwise, only prioritize contract wallets in eth_accounts if WaaS config is enabled.
+Allow blockchain accounts to handle eth_accounts filtering of account type instead if only one account; otherwise, only prioritize vault accounts for users with more than one account.

--- a/packages/bitski-provider/src/middleware/eth-accounts.ts
+++ b/packages/bitski-provider/src/middleware/eth-accounts.ts
@@ -38,8 +38,10 @@ const fetchAccounts = async (config: InternalBitskiProviderConfig): Promise<stri
     },
   )) as { accounts: BlockchainAccount[] };
 
-  const mainAccount =
-    accounts.find((a) => a.kind === 'contract-wallet') ?? accounts.find((a) => a.kind === 'bitski');
+  const mainAccount = config.waas?.enabled
+    ? accounts.find((a) => a.kind === 'contract-wallet') ??
+      accounts.find((a) => a.kind === 'bitski')
+    : accounts.find((a) => a.kind === 'bitski');
 
   if (!mainAccount) {
     throw ethErrors.rpc.internal('Could not find blockchain accounts');

--- a/packages/bitski-provider/src/middleware/eth-accounts.ts
+++ b/packages/bitski-provider/src/middleware/eth-accounts.ts
@@ -42,7 +42,23 @@ const fetchAccounts = async (config: InternalBitskiProviderConfig): Promise<stri
     throw ethErrors.rpc.internal('Could not find blockchain accounts');
   }
 
-  return accounts as unknown as string[];
+  const moreThanOneAccount = accounts.length > 1;
+  const mainAccount = config.waas?.enabled
+    ? accounts.find((a) => a.kind === 'contract-wallet') ??
+      accounts.find((a) => a.kind === 'bitski')
+    : accounts.find((a) => a.kind === 'bitski');
+
+  if (moreThanOneAccount && !mainAccount) {
+    throw ethErrors.rpc.internal('Could not find blockchain accounts');
+  }
+
+  if (moreThanOneAccount && mainAccount) {
+    return [mainAccount.address];
+  }
+
+  const accountAddresses = accounts.map((a) => a.address);
+
+  return accountAddresses;
 };
 
 export const createEthAccountsMiddleware = (): JsonRpcMiddleware<unknown[], string[]> => {

--- a/packages/bitski-provider/src/middleware/eth-accounts.ts
+++ b/packages/bitski-provider/src/middleware/eth-accounts.ts
@@ -43,10 +43,7 @@ const fetchAccounts = async (config: InternalBitskiProviderConfig): Promise<stri
   }
 
   const moreThanOneAccount = accounts.length > 1;
-  const mainAccount = config.waas?.enabled
-    ? accounts.find((a) => a.kind === 'contract-wallet') ??
-      accounts.find((a) => a.kind === 'bitski')
-    : accounts.find((a) => a.kind === 'bitski');
+  const mainAccount = accounts.find((a) => a.kind === 'bitski');
 
   if (moreThanOneAccount && !mainAccount) {
     throw ethErrors.rpc.internal('Could not find blockchain accounts');

--- a/packages/bitski-provider/src/middleware/eth-accounts.ts
+++ b/packages/bitski-provider/src/middleware/eth-accounts.ts
@@ -38,16 +38,11 @@ const fetchAccounts = async (config: InternalBitskiProviderConfig): Promise<stri
     },
   )) as { accounts: BlockchainAccount[] };
 
-  const mainAccount = config.waas?.enabled
-    ? accounts.find((a) => a.kind === 'contract-wallet') ??
-      accounts.find((a) => a.kind === 'bitski')
-    : accounts.find((a) => a.kind === 'bitski');
-
-  if (!mainAccount) {
+  if (!accounts) {
     throw ethErrors.rpc.internal('Could not find blockchain accounts');
   }
 
-  return [mainAccount.address];
+  return accounts as unknown as string[];
 };
 
 export const createEthAccountsMiddleware = (): JsonRpcMiddleware<unknown[], string[]> => {

--- a/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
+++ b/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
@@ -24,33 +24,7 @@ describe('eth-accounts middleware', () => {
     expect(result).toEqual(['0x123']);
   });
 
-  test('prioritizes contract wallets over vault wallets if more than one account and waas config enabled', async () => {
-    expect.assertions(3);
-    const provider = createTestProvider({ waas: { enabled: true } });
-
-    fetchMock.mockResponse(async (req) => {
-      expect(req.url).toBe('https://api.bitski.com/v2/blockchain/accounts');
-      expect(req.method).toBe('GET');
-
-      return JSON.stringify({
-        accounts: [
-          {
-            kind: 'bitski',
-            address: '0x123',
-          },
-          {
-            kind: 'contract-wallet',
-            address: '0x456',
-          },
-        ],
-      });
-    });
-
-    const result = await provider.request({ method: EthMethod.eth_accounts });
-    expect(result).toEqual(['0x456']);
-  });
-
-  test('prioritizes vault over contract wallets if more than one account and waas config missing', async () => {
+  test('returns vault account if multiple accounts', async () => {
     expect.assertions(3);
     const provider = createTestProvider();
 

--- a/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
+++ b/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
@@ -73,7 +73,7 @@ describe('eth-accounts middleware', () => {
     });
 
     const result = await provider.request({ method: EthMethod.eth_accounts });
-    expect(result).toEqual(['0x456']);
+    expect(result).toEqual(['0x123']);
   });
 
   test('returns accounts if only one account', async () => {

--- a/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
+++ b/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
@@ -24,6 +24,80 @@ describe('eth-accounts middleware', () => {
     expect(result).toEqual(['0x123']);
   });
 
+  test('prioritizes contract wallets over vault wallets if more than one account and waas config enabled', async () => {
+    expect.assertions(3);
+    const provider = createTestProvider({ waas: { enabled: true } });
+
+    fetchMock.mockResponse(async (req) => {
+      expect(req.url).toBe('https://api.bitski.com/v2/blockchain/accounts');
+      expect(req.method).toBe('GET');
+
+      return JSON.stringify({
+        accounts: [
+          {
+            kind: 'bitski',
+            address: '0x123',
+          },
+          {
+            kind: 'contract-wallet',
+            address: '0x456',
+          },
+        ],
+      });
+    });
+
+    const result = await provider.request({ method: EthMethod.eth_accounts });
+    expect(result).toEqual(['0x456']);
+  });
+
+  test('prioritizes vault over contract wallets if more than one account and waas config missing', async () => {
+    expect.assertions(3);
+    const provider = createTestProvider();
+
+    fetchMock.mockResponse(async (req) => {
+      expect(req.url).toBe('https://api.bitski.com/v2/blockchain/accounts');
+      expect(req.method).toBe('GET');
+
+      return JSON.stringify({
+        accounts: [
+          {
+            kind: 'bitski',
+            address: '0x123',
+          },
+          {
+            kind: 'contract-wallet',
+            address: '0x456',
+          },
+        ],
+      });
+    });
+
+    const result = await provider.request({ method: EthMethod.eth_accounts });
+    expect(result).toEqual(['0x456']);
+  });
+
+  test('returns accounts if only one account', async () => {
+    expect.assertions(3);
+    const provider = createTestProvider();
+
+    fetchMock.mockResponse(async (req) => {
+      expect(req.url).toBe('https://api.bitski.com/v2/blockchain/accounts');
+      expect(req.method).toBe('GET');
+
+      return JSON.stringify({
+        accounts: [
+          {
+            kind: 'bitski',
+            address: '0x123',
+          },
+        ],
+      });
+    });
+
+    const result = await provider.request({ method: EthMethod.eth_accounts });
+    expect(result).toEqual(['0x123']);
+  });
+
   test('uses access token if available', async () => {
     expect.assertions(4);
     const provider = createTestProvider({

--- a/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
+++ b/packages/bitski-provider/tests/middlewares/eth-accounts.test.ts
@@ -24,32 +24,6 @@ describe('eth-accounts middleware', () => {
     expect(result).toEqual(['0x123']);
   });
 
-  test('prioritizes contract wallets over vault wallets', async () => {
-    expect.assertions(3);
-    const provider = createTestProvider();
-
-    fetchMock.mockResponse(async (req) => {
-      expect(req.url).toBe('https://api.bitski.com/v2/blockchain/accounts');
-      expect(req.method).toBe('GET');
-
-      return JSON.stringify({
-        accounts: [
-          {
-            kind: 'bitski',
-            address: '0x123',
-          },
-          {
-            kind: 'contract-wallet',
-            address: '0x456',
-          },
-        ],
-      });
-    });
-
-    const result = await provider.request({ method: EthMethod.eth_accounts });
-    expect(result).toEqual(['0x456']);
-  });
-
   test('uses access token if available', async () => {
     expect.assertions(4);
     const provider = createTestProvider({


### PR DESCRIPTION
Pass through response from blockchain accounts if one account, and allow filtering to be done by the subgraph/backend; otherwise if more than one account, only prioritize contract wallet if waas config enabled, otherwise prioritize vault.