### PR TITLE
Add default view for connected state; add Login button

### DIFF
--- a/.changeset/forty-bags-tap.md
+++ b/.changeset/forty-bags-tap.md
@@ -2,4 +2,15 @@
 '@bitski/waas-react-sdk': patch
 ---
 
-Extend the Widget to accept children which will dictate the connected view. If no children, we will show a default view. In addition, enable a collapsed state for widget via the "collapsed" prop. If provided, the widget will initially show as a login button.
+- Added children, collapsed, and loginText props to BitskiWidget
+
+<BitskiWidget collapsed>
+- To show login button initially before showing the auth view
+
+<BitskiWidget collapsed displayText="Connect">
+- You can set displayText prop to customize the button's text
+
+<BitskiWidget>
+  <h1>Hello, world!</h1>
+</BitskiWidget>
+- Customize the connected state to display your own UI if desired. This can instead be a list of links for user settings or application settings. Or your own display of address and chains.

--- a/.changeset/forty-bags-tap.md
+++ b/.changeset/forty-bags-tap.md
@@ -1,0 +1,5 @@
+---
+'@bitski/waas-react-sdk': patch
+---
+
+Extend the Widget to accept children which will dictate the connected view. If no children, we will show a default view. In addition, enable a collapsed state for widget via the "collapsed" prop. If provided, the widget will initially show as a login button.

--- a/packages/waas-react-sdk/README.md
+++ b/packages/waas-react-sdk/README.md
@@ -1,5 +1,7 @@
 # @bitski/waas-react-sdk
 
+> DISCLAIMER: While we are under v1.0.0 - please expect breaking changes. All changes will be communicated via the CHANGELOG.md
+
 Solve all your dApp’s authentication challenges with a simple React Widget.
 
 We aim to use tools you are already familiar with, mainly Wagmi and Viem so you can focus on building your application.

--- a/packages/waas-react-sdk/src/App.tsx
+++ b/packages/waas-react-sdk/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
         chains={[providerConfig.chains[0], ...providerConfig.chains]}
         loginMethods={providerConfig.loginMethods}
       >
-        <BitskiWidget logoUrl={`https://i.imgur.com/QYSwQ00.png`} />
+        <BitskiWidget logoUrl="https://i.imgur.com/QYSwQ00.png" />
       </BitskiProvider>
     </div>
   );

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiAuth.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiAuth.tsx
@@ -6,7 +6,13 @@ import Connected from './states/Connected';
 import ConnectionError from './states/ConnectionError';
 import { ConnectionState } from './constants';
 
-export function BitskiAuth(props: { logoUrl?: string }) {
+interface BitskiAuthProps {
+  children?: React.ReactNode;
+  logoUrl?: string;
+  onBack?: () => void;
+}
+
+export function BitskiAuth({ children, logoUrl, onBack }: BitskiAuthProps) {
   const { connectionState, connectWallet, disconnectWallet, reset } = useConnectionState();
 
   const { pendingConnector } = connectionState as PendingState;
@@ -14,7 +20,7 @@ export function BitskiAuth(props: { logoUrl?: string }) {
 
   switch (connectionState.type) {
     case ConnectionState.Idle:
-      return <IdleConnection connectWallet={connectWallet} logoUrl={props.logoUrl} />;
+      return <IdleConnection connectWallet={connectWallet} onBack={onBack} logoUrl={logoUrl} />;
     case ConnectionState.Pending:
       return <PendingConnection connector={pendingConnector} reset={reset} />;
     case ConnectionState.Connected:
@@ -24,11 +30,13 @@ export function BitskiAuth(props: { logoUrl?: string }) {
           chainName={chain}
           address={address}
           disconnect={() => disconnectWallet({ connector })}
-        />
+        >
+          {children}
+        </Connected>
       );
     case ConnectionState.Error:
       return <ConnectionError reset={reset} connector={connectionState.connector} />;
     default:
-      return <IdleConnection connectWallet={connectWallet} />;
+      return <IdleConnection connectWallet={connectWallet} onBack={onBack} logoUrl={logoUrl} />;
   }
 }

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiConnect.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiConnect.tsx
@@ -1,0 +1,17 @@
+interface BitskiConnectProps {
+  displayText?: string;
+  onClick: () => void;
+}
+
+export const BitskiConnect = ({ displayText = 'Login', onClick }: BitskiConnectProps) => {
+  return (
+    <button
+      className="bg-[color:var(--main-obsidian)] flex h-11 flex-col justify-center items-center px-5 py-0 rounded-2xl"
+      onClick={onClick}
+    >
+      <p className="text-[color:var(--main-white,color(display-p3_1_1_1))] text-center text-[13px] not-italic font-[590] leading-[13px]">
+        {displayText}
+      </p>
+    </button>
+  );
+};

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiWidget.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/BitskiWidget.tsx
@@ -1,11 +1,37 @@
+import { useCallback, useState } from 'react';
 import { BitskiAuth } from './BitskiAuth';
+import { BitskiConnect } from './BitskiConnect';
 
 export interface BitskiWidgetProps {
-  logoUrl?: string
+  children?: React.ReactNode;
+  collapsed?: boolean;
+  logoUrl?: string;
+  loginText?: string;
 }
 
-function BitskiWidget({ logoUrl }: BitskiWidgetProps) {
-  return <BitskiAuth logoUrl={logoUrl}  />;
+function BitskiWidget({ children, collapsed = false, logoUrl, loginText }: BitskiWidgetProps) {
+  console.log('widget has children', children);
+  const [showAuth, setShowAuth] = useState(false);
+
+  const displayAuth = useCallback(() => {
+    setShowAuth(true);
+  }, []);
+
+  const hideAuth = useCallback(() => {
+    setShowAuth(false);
+  }, []);
+
+  if (!collapsed) {
+    return <BitskiAuth logoUrl={logoUrl}>{children}</BitskiAuth>;
+  }
+
+  return showAuth ? (
+    <BitskiAuth logoUrl={logoUrl} onBack={hideAuth}>
+      {children}
+    </BitskiAuth>
+  ) : (
+    <BitskiConnect displayText={loginText} onClick={displayAuth} />
+  );
 }
 
 export default BitskiWidget;

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Connected.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Connected.tsx
@@ -18,7 +18,30 @@ export default function Connected(props: {
   chainName: string;
   address: string;
   disconnect: () => void;
+  children?: React.ReactNode;
 }) {
+  return (
+    <div className="flex flex-col items-start gap-6">
+      {props.children ? (
+        props.children
+      ) : (
+        <DefaultConnectView
+          connector={props.connector}
+          chainName={props.chainName}
+          address={props.address}
+          disconnect={props.disconnect}
+        />
+      )}
+    </div>
+  );
+}
+
+export const DefaultConnectView = (props: {
+  connector: Connector;
+  chainName: string;
+  address: string;
+  disconnect: () => void;
+}) => {
   const { signMessageAsync } = useSignMessage();
   const [signedMessageState, setSignedMessageState] = useState<SignedMessageState>({
     type: SignedMessageStateType.Rest,
@@ -42,7 +65,7 @@ export default function Connected(props: {
   }
 
   return (
-    <div className="flex flex-col items-start gap-6">
+    <>
       <div className="flex w-[375px] flex-col items-start gap-6 shadow-[0px_10px_40px_0px_color(display-p3_0_0.0667_0.2_/_0.10)] p-6 rounded-2xl bg-white">
         <div className="flex h-[150px] flex-col justify-center items-center gap-2.5 self-stretch rounded-xl bg-[var(--aux-light-grey)]">
           <div className="flex justify-center items-center gap-2 pl-2.5 pr-3 py-2 rounded-xl bg-[var(--aux-grey)]">
@@ -108,9 +131,9 @@ export default function Connected(props: {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
-}
+};
 
 function shortenEthereumAddress(address: string) {
   if (!address || address.length !== 42 || !address.startsWith('0x')) {

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Idle.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Idle.tsx
@@ -5,17 +5,21 @@ import { ExternalWallet, Social } from '../constants';
 import Wallets from '../Wallets';
 import TOS from '../TOS';
 import Socials from '../Socials';
+import chevronLeftSmall from '../../../assets/chevron-left-small.svg';
 
-export default function IdleConnection(props: {
+interface IdleConnectionProps {
   connectWallet: ({
     connector,
     parameters,
   }: {
     connector: Connector;
     parameters?: Record<string, unknown>;
-  }) => void,
-  logoUrl?: string
-}) {
+  }) => void;
+  onBack?: () => void;
+  logoUrl?: string;
+}
+
+export default function IdleConnection({ connectWallet, onBack, logoUrl }: IdleConnectionProps) {
   const config = useConfig();
 
   const connectors = config.connectors;
@@ -27,21 +31,26 @@ export default function IdleConnection(props: {
   const showOrDivider = (bitskiConnector || socialConnectors.length) && walletConnectors.length;
 
   return (
-    <div className="flex w-[350px] flex-col items-center gap-6 shadow-[0px_10px_40px_0px_color(display-p3_0_0.0667_0.2_/_0.10)] pt-7 pb-0 px-8 rounded-3xl bg-white">
+    <div className="relative flex w-[350px] flex-col items-center gap-6 shadow-[0px_10px_40px_0px_color(display-p3_0_0.0667_0.2_/_0.10)] pt-7 pb-0 px-8 rounded-3xl bg-white">
+      {onBack ? (
+        <div className="w-6 h-6 absolute left-6 top-[23.5px]">
+          <button onClick={onBack}>
+            <img src={chevronLeftSmall} alt="Back" />
+          </button>
+        </div>
+      ) : null}
       <p className="text-[color:var(--main-grey)] text-sm not-italic font-[590] leading-[17px] tracking-[-0.28px]">
         Login or Sign Up
       </p>
-      {props.logoUrl ? (
-        <img className="w-12 h-12" src={props.logoUrl} alt="Logo" />
-      ) : null}
+      {logoUrl ? <img className="w-12 h-12" src={logoUrl} alt="Logo" /> : null}
       {bitskiConnector ? (
         <div className="flex flex-col items-center gap-3 self-stretch">
-          <EmailInput connector={bitskiConnector} connect={props.connectWallet} />
+          <EmailInput connector={bitskiConnector} connect={connectWallet} />
         </div>
       ) : null}
 
       {socialConnectors.length ? (
-        <Socials onSocialClick={(social) => props.connectWallet({ connector: social.connector })} />
+        <Socials onSocialClick={(social) => connectWallet({ connector: social.connector })} />
       ) : null}
 
       {showOrDivider ? (
@@ -55,7 +64,7 @@ export default function IdleConnection(props: {
       ) : null}
 
       {walletConnectors.length ? (
-        <Wallets onWalletClick={(wallet) => props.connectWallet({ connector: wallet.connector })} />
+        <Wallets onWalletClick={(wallet) => connectWallet({ connector: wallet.connector })} />
       ) : null}
       <TOS />
     </div>

--- a/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Pending.tsx
+++ b/packages/waas-react-sdk/src/lib/components/BitskiWidget/states/Pending.tsx
@@ -1,6 +1,7 @@
 import { Connector } from 'wagmi';
 import { iconForConnector } from './ConnectionError';
 
+import chevronLeftSmall from '../../../assets/chevron-left-small.svg';
 import pendingIcon from '../../../assets/pending.svg';
 
 export default function PendingConnection(props: { connector: Connector; reset: () => void }) {
@@ -8,7 +9,7 @@ export default function PendingConnection(props: { connector: Connector; reset: 
     <div className="relative flex w-[350px] flex-col items-center gap-6 shadow-[0px_4px_12px_0px_color(display-p3_0_0_0_/_0.12)] p-8 rounded-3xl bg-white">
       <div className="w-6 h-6 absolute left-6 top-[23.5px]">
         <button onClick={props.reset}>
-          <img src={pendingIcon} alt="Back" />
+          <img src={chevronLeftSmall} alt="Back" />
         </button>
       </div>
       <div className="flex justify-center items-center flex-[1_0_0] self-stretch p-[6.667px]">


### PR DESCRIPTION
- If user provides children to `BitskiWidget`, we will render the children on `Connected` state
- Otherwise, we will show the default "Demo" view
- Add a button state for showing widget as Login button first before opening wider widget

# Default
https://github.com/BitskiCo/bitski-js/assets/4204797/3a65fb0f-6f45-4d72-bcd7-e23a67b6c53f



# Login Button
https://github.com/BitskiCo/bitski-js/assets/4204797/874d194f-32a0-436d-b2ea-73a81681b294



# Custom Connection UI
https://github.com/BitskiCo/bitski-js/assets/4204797/845a980d-58fe-4691-b674-803e50eb3451

